### PR TITLE
Fix listening address in example

### DIFF
--- a/_includes/sample_code.md
+++ b/_includes/sample_code.md
@@ -7,6 +7,6 @@ server = HTTP::Server.new(8080) do |context|
   context.response.print "Hello world, got #{context.request.path}!"
 end
 
-puts "Listening on http://0.0.0.0:8080"
+puts "Listening on http://127.0.0.1:8080"
 server.listen
 {% endhighlight %}


### PR DESCRIPTION
The default listening address for HTTP::Server is 127.0.0.1, not 0.0.0.0.