### PR TITLE
Fix typo on 'Eventbrite'

### DIFF
--- a/_includes/bannerSF2017.html
+++ b/_includes/bannerSF2017.html
@@ -5,8 +5,8 @@
         <span class="crystal-codecamp">CRYSTAL CODECAMP</span> <span class="sf">| SF2017</span>
         <div class="center-align right">
           <span class="date">May 11-12 at AcademyX San Francisco</span>
-          <span class="register">REGISTER AT <em>Evenbrite</em></span>
-          <div class="register-mobile ">REGISTER AT <span>Evenbrite</span></div>
+          <span class="register">REGISTER AT <em>Eventbrite</em></span>
+          <div class="register-mobile ">REGISTER AT <span>Eventbrite</span></div>
         </div>
       </a>
     </div>


### PR DESCRIPTION
Noticed this typo on the main page banner after a fellow Rubyist told me to go check out Crystal.  Looking interesting, thanks!