### PR TITLE
Add the term mailing list for searchbility

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -28,7 +28,7 @@ nav_order: 4
 {% include community_row.html
           title="General Discussion"
           divId="discuss"
-          content="The crystal-lang Google Group is the first to-go place for any general discussion. Feel free to ask a question, share your project with others, ask for guidance and best practices, offer your help contributing to a project, or anything else Crystal-related."
+          content="The crystal-lang Google Groups mailing list is the first to-go place for any general discussion. Feel free to ask a question, share your project with others, ask for guidance and best practices, offer your help contributing to a project, or anything else Crystal-related."
           link_text="crystal-lang"
           url="https://groups.google.com/forum/#!forum/crystal-lang"
           icon="google"


### PR DESCRIPTION
I was trying to find the mailing list and that term was not on the page, so this adds it in.

Note that this was actually the section title prior to 1bf65b101ac9c7f13b71b839672bc0c365895fb9 , which changed it from "Mailing List" to "General Discussion".  I'm not sure why that change was made, so I could also just change the section title if that's preferable.