### PR TITLE
Change server sample of Crystal 0.25

### DIFF
--- a/_includes/sample_server.md
+++ b/_includes/sample_server.md
@@ -2,11 +2,11 @@
 # A very basic HTTP server
 require "http/server"
 
-server = HTTP::Server.new(8080) do |context|
+server = HTTP::Server.new do |context|
   context.response.content_type = "text/plain"
   context.response.print "Hello world, got #{context.request.path}!"
 end
 
 puts "Listening on http://127.0.0.1:8080"
-server.listen
+server.listen(8080)
 {% endhighlight %}


### PR DESCRIPTION
The usage of `HTTP::Server` changed in https://github.com/crystal-lang/crystal/pull/5776 that will be available in next Crystal release (0.25).

This PR should be merged when 0.25 is released :)