### PR TITLE
Fix stack overflow Pull Request link

### DIFF
--- a/_posts/2018-11-01-crystal-0.27.0-released.md
+++ b/_posts/2018-11-01-crystal-0.27.0-released.md
@@ -38,7 +38,7 @@ Sometimes a program will enter an infinite recursion or, due to another reason, 
 
 This was a long standing issue and at the end of the day it was a collaboration that pushed an initial proof of concept implementation to a complete solution and closed one of the top 10 oldest issues.
 
-Read more at [#6928](https://github.com/crystal-lang/crystal/pull/6648).
+Read more at [#6928](https://github.com/crystal-lang/crystal/pull/6928).
 
 # Concurrency and parallelism changes
 


### PR DESCRIPTION
It currently leads to [`#6648`](https://github.com/crystal-lang/crystal/pull/6648).