### PR TITLE
Fixed decimal_places example

### DIFF
--- a/_posts/2019-05-08-formatting-pretty-numbers-for-humans.md
+++ b/_posts/2019-05-08-formatting-pretty-numbers-for-humans.md
@@ -46,7 +46,7 @@ The number of decimal places can be configured directly in the `#format` method:
 
 <div class="code_section">{% highlight crystal %}
 123_456.789.format(decimal_places: 2) # => "123,456.79"
-123_456.789.format(decimal_places: 0) # => "123,456"
+123_456.789.format(decimal_places: 0) # => "123,457"
 123_456.789.format(decimal_places: 4) # => "123,456.7890"
 {% endhighlight crystal %}</div>
 


### PR DESCRIPTION
Fixed the output shown for the decimal_places example to show that rounding works correctly (rather than the implied truncation shown).