### PR TITLE
[CSS] Fix overlap between .sponsorships and .main-actions

### DIFF
--- a/_assets/css/_generic.scss
+++ b/_assets/css/_generic.scss
@@ -150,6 +150,13 @@ table.no-underline a {
   min-height: 465px;
   width: 100%;
 
+  // This padding makes room for .banner.sponsorship to overlap into .header-section
+  padding-bottom: 30px;
+  @media only screen and (max-width: 768px) {
+    // On small width, .banner.sponsorship spans over two lines, needing more space
+    padding-bottom: 45px;
+  }
+
   .title {
     color: $black;
     font-size: 72px;

--- a/_assets/css/_home.scss
+++ b/_assets/css/_home.scss
@@ -2,8 +2,8 @@
   // Changes to the default layout for main page
   .header-section {
     background-color: transparent;
-    height: calc(70vh - 114px);
     min-height: 485px;
+    position: relative;
     h1.title {
       color: $white;
     }
@@ -62,10 +62,9 @@
   #delaunay {
     @extend .black;
     position: absolute;
-    top: 0;
+    top: -94px;
     right: 0;
-    min-height: 600px;
-    height: 70vh;
+    bottom: 0;
     left: 0;
     z-index: -1;
   }
@@ -73,6 +72,7 @@
   canvas.delaunay {
     position: absolute;
     background-color: $black;
+    bottom: 0;
   }
 
   .container {
@@ -156,6 +156,7 @@
     padding: 2px 25px;
     white-space: nowrap;
     z-index: 1;
+    transform: translateY(-50%);
     h3 {
       display: inline-block;
       background-color: $white;
@@ -165,21 +166,13 @@
       border-bottom: 1px solid $primary-text;
       margin-left: 8px;
     }
-    &:before {
-      content:"";
-      display: block;
-      border-top: 1px solid $light-gray;
-      position: absolute;
-      margin-top: 15px;
-      width: 100%;
-      left: 0;
-      z-index: -1;
-    }
   }
 
 
   .banner.sponsorship {
     margin-top: 0;
+    border-top: 1px solid $light-gray;
+
     .flag-logos {
       display: inline;
       span {

--- a/_assets/css/_home.scss
+++ b/_assets/css/_home.scss
@@ -72,7 +72,8 @@
   canvas.delaunay {
     position: absolute;
     background-color: $black;
-    bottom: 0;
+    top: 0;
+    bottom: 15px;
   }
 
   .container {


### PR DESCRIPTION
Currently, on screen sizes smaller than 992px, `.sponsorship` overlaps `.main-actions` buttons.

![image](https://user-images.githubusercontent.com/466378/64486945-49373d00-d234-11e9-85c8-fa16da59b8a9.png)

This PR fixes that.

* removes height calculation from `.header-section`, instead fits `#delaunay` to parent height
* adds a bottom padding to `.header-section #content`
* moves `.main-actions` upward using `transform`

