### PR TITLE
Use clearer method & avoid confusing var

### DIFF
--- a/_includes/sample_concurrency.md
+++ b/_includes/sample_concurrency.md
@@ -5,8 +5,8 @@ files = Dir.glob("*.txt")
 
 files.each do |f|
   spawn do
-    lines = File.read(f).lines.size
-    channel.send lines
+    lines = File.read_lines(f)
+    channel.send lines.size
   end
 end
 


### PR DESCRIPTION
I found the variable name `lines` to be confusing, as it's not really the lines of the `file` but the number of lines. Switching to `File.read_lines` and sending `lines.size` reads a little more clear to me.