### PR TITLE
Fix broken links and add link validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,30 @@
 language: ruby
-rvm: 2.5.1
+rvm: 2.5.3
 sudo: false
+
 cache:
   directories:
     - vendor/bundle
-before_install: |
-  gem update --system
-  gem install bundler
-  bundle install --deployment --jobs=3 --retry=3
-script: test $TRAVIS_PULL_REQUEST != "false" || bundle exec jekyll build
+    - $TRAVIS_BUILD_DIR/tmp/.htmlproofer # https://github.com/gjtorikian/html-proofer/issues/381
+
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+before_install:
+- gem update --system
+- gem install bundler html-proofer
+- bundle install --deployment --jobs=3 --retry=3
+
+script:
+- make check_html
+- make check_external_links || true # allowed to fail
+
 branches:
   only:
     - master
     - unstable
+
 deploy:
   - provider: s3
     access_key_id: AKIAIRL4BWFPN7P54TBQ

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+OUTPUT_DIR ?= _site
+
+.PHONY: build
+build: $(OUTPUT_DIR)
+
+$(OUTPUT_DIR):
+	bundle exec jekyll build --destination $(OUTPUT_DIR)
+
+.PHONY: check_html
+check_html: $(OUTPUT_DIR)
+	htmlproofer $(OUTPUT_DIR) \
+		--assume-extension \
+		--url-swap "\A\/(api|docs|images|reference):https://crystal-lang.org/\1" \
+		--disable_external \
+		--allow-hash-href \
+		--checks-to-ignore ImageCheck \
+		--check-img-http
+
+.PHONY: check_external_links
+check_external_links: $(OUTPUT_DIR)
+	htmlproofer $(OUTPUT_DIR) \
+		--assume-extension \
+		--url-swap "\A\/(api|docs|images|reference):https://crystal-lang.org/\1" \
+		--url-ignore "http://0.0.0.0:8080" \
+		--http-status-ignore 999 \
+		--external_only
+
+.PHONY: clean
+clean:
+	rm -rf $(OUTPUT_DIR)

--- a/_posts/2013-12-05-garbage-collector.md
+++ b/_posts/2013-12-05-garbage-collector.md
@@ -5,7 +5,7 @@ thumbnail: gc
 author: waj
 ---
 
-Finally Crystal will start giving some memory back to the operating system! Today we managed to fit the [Boehm-Demers-Weiser conservative garbage collector](http://www.hpl.hp.com/personal/Hans_Boehm/gc/) into the language.
+Finally Crystal will start giving some memory back to the operating system! Today we managed to fit the [Boehm-Demers-Weiser conservative garbage collector](https://www.hboehm.info/gc/) into the language.
 
 Although we plan to implement a more appropriate and custom garbage collector in the future, it's a really good starting point to make the language more robust and usable.
 

--- a/_posts/2014-12-04-crystal-0.5.4-released.md
+++ b/_posts/2014-12-04-crystal-0.5.4-released.md
@@ -44,7 +44,7 @@ p person #=> #<Person:0x10220CF20 @name="John", @age=30>
 
 Please read the [Changelog](https://github.com/crystal-lang/crystal/releases/tag/0.5.4) for all the details.
 
-You can install Crystal by following [these instructions](http://crystal-lang.org/docs/installation/README.html).
+You can install Crystal by following [these instructions](https://crystal-lang.org/install).
 
 We'd like to thank everyone that help us by sending pull requests, suggesting improvements and changes,
 adding documentation, fixing tpyos and talking about it in social media like [Twitter](https://twitter.com/search?q=crystal-lang.org)

--- a/_posts/2014-12-04-crystal-0.5.4-released.md
+++ b/_posts/2014-12-04-crystal-0.5.4-released.md
@@ -44,7 +44,7 @@ p person #=> #<Person:0x10220CF20 @name="John", @age=30>
 
 Please read the [Changelog](https://github.com/crystal-lang/crystal/releases/tag/0.5.4) for all the details.
 
-You can install Crystal by following [these instructions](https://crystal-lang.org/install).
+You can install Crystal by following [these instructions](/install).
 
 We'd like to thank everyone that help us by sending pull requests, suggesting improvements and changes,
 adding documentation, fixing tpyos and talking about it in social media like [Twitter](https://twitter.com/search?q=crystal-lang.org)

--- a/install/on_arch_linux.md
+++ b/install/on_arch_linux.md
@@ -5,7 +5,7 @@ exclude: true
 permalink: /install/on_arch_linux/
 ---
 
-Arch Linux includes the Crystal compiler in the Community repository. You should also install `shards`, Crystal's dependency manager (see [The Shards command](/reference/the_shards_command/)).
+Arch Linux includes the Crystal compiler in the Community repository. You should also install `shards`, Crystal's dependency manager (see [The Shards command](https://crystal-lang.org/reference/the_shards_command/)).
 [Snapcraft](#snapcraft) is also available.
 
 ## Install

--- a/install/on_arch_linux.md
+++ b/install/on_arch_linux.md
@@ -5,7 +5,7 @@ exclude: true
 permalink: /install/on_arch_linux/
 ---
 
-Arch Linux includes the Crystal compiler in the Community repository. You should also install `shards`, Crystal's dependency manager (see [The Shards command](../the_shards_command/README.md)).
+Arch Linux includes the Crystal compiler in the Community repository. You should also install `shards`, Crystal's dependency manager (see [The Shards command](/reference/the_shards_command/)).
 [Snapcraft](#snapcraft) is also available.
 
 ## Install

--- a/install/on_mac_os.md
+++ b/install/on_mac_os.md
@@ -14,7 +14,7 @@ brew install crystal
 
 You should be able to install the latest version from homebrew. Crystal's core-team help maintain that formula.
 
-Alternative there are `.tar.gz` and `.pkg` files in each [release](https://github.com/crystal-lang/crystal/releases) targeted for darwin. See [Install from a tar.gz](/install/from_a_targz)
+Alternative there are `.tar.gz` and `.pkg` files in each [release](https://github.com/crystal-lang/crystal/releases) targeted for darwin. See [Install from a tar.gz](/install/from_targz)
 
 ## Upgrade
 

--- a/install/on_wsl.md
+++ b/install/on_wsl.md
@@ -7,4 +7,4 @@ permalink: /install/on_wsl/
 
 The Crystal compiler doesn't run on Windows _yet_. But Crystal can be used with the [Windows Subsystem for Linux](https://msdn.microsoft.com/en-us/commandline/wsl/about), a compatibility-layer for Linux executables running natively on Windows 10.
 
-Several Linux distribution are supported by WSL and the installation instructions for Crystal are equal to that of the respective Linux distribution, most commonly [Debian](../on_debian) and [Ubuntu](../on_ubuntu).
+Several Linux distribution are supported by WSL and the installation instructions for Crystal are equal to that of the respective Linux distribution, most commonly [Debian](/install/on_debian) and [Ubuntu](/install/on_ubuntu).

--- a/install/on_wsl.md
+++ b/install/on_wsl.md
@@ -7,4 +7,4 @@ permalink: /install/on_wsl/
 
 The Crystal compiler doesn't run on Windows _yet_. But Crystal can be used with the [Windows Subsystem for Linux](https://msdn.microsoft.com/en-us/commandline/wsl/about), a compatibility-layer for Linux executables running natively on Windows 10.
 
-Several Linux distribution are supported by WSL and the installation instructions for Crystal are equal to that of the respective Linux distribution, most commonly [Debian](on_debian) and [Ubuntu](on_ubuntu).
+Several Linux distribution are supported by WSL and the installation instructions for Crystal are equal to that of the respective Linux distribution, most commonly [Debian](../on_debian) and [Ubuntu](../on_ubuntu).


### PR DESCRIPTION
The first commit fixes broken links.
The second one addds [html-proofer](https://github.com/gjtorikian/html-proofer) to validate generated output, including links.

There are still a few broken external links that were not as easy to resolve. For now `check_internal_links`  is allowed to fail.
We could consider updating the links as far as possible (which means digging up their new locations), simply remove them or ignore them in the link checker.