### PR TITLE
Add edit-on-github link

### DIFF
--- a/_layouts/install.html
+++ b/_layouts/install.html
@@ -19,4 +19,8 @@ exclude: true
   <h2>Found any issues?</h2>
   <a href="https://forum.crystal-lang.org/c/help-support" target="_blank" class="btn btn-large btn-flat">Forum
     support</a>.
+
+  <a href="https://github.com/crystal-lang/crystal-website/edit/unstable/{{ page.path }}"" target="_blank" class="btn btn-large btn-flat">
+    Edit this page on Github
+  </a>
 </div>


### PR DESCRIPTION
This PR adds a link to Github's edit feature from each install page to encourage readers to fix issues when they notice something is wrong.

We could just add it as such or extend the link to other pages as well. Maybe in the footer? But I figured this is a good start anyway.