### PR TITLE
Refactor permalinks for install pages to centralized config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,14 @@ defaults:
       image: /images/icon.png
       layout: post
       is_post: true
+  -
+    scope:
+      path: "install"
+      type: pages
+    values:
+      image: /images/icon.png
+      layout: install
+      permalink: /install/:basename/
 twitter:
   username: CrystalLanguage
 

--- a/install/from_sources.md
+++ b/install/from_sources.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: From sources
-permalink: /install/from_sources/
 ---
 
 If you want to contribute then you might want to install Crystal from sources.

--- a/install/from_targz.md
+++ b/install/from_targz.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: From tar.gz
-permalink: /install/from_targz/
 ---
 
 You can download Crystal in a standalone `.tar.gz` file with everything you need to get started.

--- a/install/index.html
+++ b/install/index.html
@@ -1,6 +1,8 @@
 ---
 title: Install
 description: You can install Crystal in different ways. Select your platform to find specific instructions.
+layout: default
+permalink: /install/
 ---
 <div class="container">
   <div class="row">

--- a/install/on_alpine_linux.md
+++ b/install/on_alpine_linux.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Alpine Linux
-permalink: /install/on_alpine_linux/
 ---
 
 Alpine Linux includes the Crystal compiler in the community repository, starting from version Alpine 3.7.

--- a/install/on_arch_linux.md
+++ b/install/on_arch_linux.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Arch Linux
-permalink: /install/on_arch_linux/
 ---
 
 Arch Linux includes the Crystal compiler in the Community repository. You should also install `shards`, Crystal's dependency manager (see [The Shards command](https://crystal-lang.org/reference/the_shards_command/)).

--- a/install/on_centos.md
+++ b/install/on_centos.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On CentOS
-permalink: /install/on_centos/
 ---
 
 In Red Hat derived distributions, you can use the official Crystal repository.

--- a/install/on_debian.md
+++ b/install/on_debian.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Debian
-permalink: /install/on_debian/
 ---
 
 In Debian derived distributions, you can use the official Crystal repository. [Snapcraft](#snapcraft) and [Linuxbrew](#linuxbrew) are also available.

--- a/install/on_elementary_os.md
+++ b/install/on_elementary_os.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Elementary OS
-permalink: /install/on_elementary_os/
 ---
 
 {% include install_from_snapcraft.md distro="elementary" %}

--- a/install/on_fedora.md
+++ b/install/on_fedora.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Fedora
-permalink: /install/on_fedora/
 ---
 
 {% include install_from_snapcraft.md distro="fedora" %}

--- a/install/on_freebsd.md
+++ b/install/on_freebsd.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On FreeBSD
-permalink: /install/on_freebsd/
 ---
 
 FreeBSD includes the Crystal compiler in the ports tree, starting from version FreeBSD 11.0.

--- a/install/on_gentoo_linux.md
+++ b/install/on_gentoo_linux.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Gentoo Linux
-permalink: /install/on_gentoo_linux/
 ---
 
 Gentoo Linux includes the Crystal compiler in the main overlay.

--- a/install/on_kde_neon.md
+++ b/install/on_kde_neon.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On KDE Neon
-permalink: /install/on_kde_neon/
 ---
 
 {% include install_from_snapcraft.md distro="kde-neon" %}

--- a/install/on_kubuntu.md
+++ b/install/on_kubuntu.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Kubuntu
-permalink: /install/on_kubuntu/
 ---
 
 In Ubuntu derived distributions, you can use the official Crystal repository. [Snapcraft](#snapcraft) and [Linuxbrew](#linuxbrew) are also available.

--- a/install/on_linux_mint.md
+++ b/install/on_linux_mint.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Linux Mint
-permalink: /install/on_linux_mint/
 ---
 
 {% include install_from_snapcraft.md distro="mint" %}

--- a/install/on_mac_os.md
+++ b/install/on_mac_os.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On macOS
-permalink: /install/on_mac_os/
 ---
 
 To easily install Crystal on macOS you can use [Homebrew](http://brew.sh/).

--- a/install/on_manjaro.md
+++ b/install/on_manjaro.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Manjaro
-permalink: /install/on_manjaro/
 ---
 
 {% include install_from_snapcraft.md distro="manjaro" %}

--- a/install/on_opensuse.md
+++ b/install/on_opensuse.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On OpenSUSE
-permalink: /install/on_opensuse/
 ---
 
 On OpenSUSE, Crystal can be installed from the official rpm package using Zypper.

--- a/install/on_redhat.md
+++ b/install/on_redhat.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Red Hat
-permalink: /install/on_redhat/
 ---
 
 In Red Hat derived distributions, you can use the official Crystal repository.

--- a/install/on_ubuntu.md
+++ b/install/on_ubuntu.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Ubuntu
-permalink: /install/on_ubuntu/
 ---
 
 In Ubuntu derived distributions, you can use the official Crystal repository. [Snapcraft](#snapcraft) and [Linuxbrew](#linuxbrew) are also available.

--- a/install/on_wsl.md
+++ b/install/on_wsl.md
@@ -1,7 +1,5 @@
 ---
-layout: install
 subtitle: On Windows Subsystem for Linux
-permalink: /install/on_wsl/
 ---
 
 The Crystal compiler doesn't run on Windows _yet_. But Crystal can be used with the [Windows Subsystem for Linux](https://msdn.microsoft.com/en-us/commandline/wsl/about), a compatibility-layer for Linux executables running natively on Windows 10.


### PR DESCRIPTION
Just a small improvement to DRY.

This does not change the output.

`exclude: true` could be scrapped as well, but that's entirely obsolete with #93 anyway.