### PR TITLE
Add docs page

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -9,11 +9,7 @@ main:
   url: /sponsors/
 - label: Community
   url: /community/
-- label: Media
-  url: /media/
 - label: Docs
-  url: https://crystal-lang.org/reference/
-- label: API
-  url: https://crystal-lang.org/api/
+  url: /docs/
 - label: GitHub
   url: https://github.com/crystal-lang/crystal

--- a/_includes/community_row.html
+++ b/_includes/community_row.html
@@ -1,5 +1,5 @@
 <div class="row{% if include.continues %} no-bottom-margin{% endif %}"{% if include.divId %} id="{{ include.divId }}"{%endif%}>
-  <div class="col">
+  <div class="col s12">
     <h2>{{ include.title }}</h2>
 
     <p>{{ include.content }}</p>

--- a/docs.html
+++ b/docs.html
@@ -11,7 +11,7 @@ permalink: /docs/
           content="Documentation of the Crystal language and compiler features."
           link_text="crystal-lang.org/reference"
           url="https://crystal-lang.org/reference"
-          icon="web_asset"
+          icon="menu_book"
 %}
 
 {% include community_row.html
@@ -20,7 +20,7 @@ permalink: /docs/
           content="Documentation for the Crystal standard-library."
           link_text="crystal-lang.org/api"
           url="https://crystal-lang.org/api"
-          icon="web_asset"
+          icon="explore"
 %}
 
 {% include community_row.html
@@ -29,7 +29,7 @@ permalink: /docs/
           content="Installation instructions for Crystal."
           link_text="crystal-lang.org/install"
           url="/install"
-          icon="web_asset"
+          icon="get_app"
 %}
 
 {% include community_row.html
@@ -38,7 +38,7 @@ permalink: /docs/
           content="Logos and style guide."
           link_text="crystal-lang.org/media"
           url="/media"
-          icon="web_asset"
+          icon="palette"
 %}
 
 {% include community_row.html
@@ -57,4 +57,5 @@ permalink: /docs/
           content="Documentation for official shards."
           link_text="crystal-db"
           url="http://crystal-lang.github.io/crystal-db/api/latest/"
+          icon="apps"
 %}

--- a/docs.html
+++ b/docs.html
@@ -1,0 +1,60 @@
+---
+title: Documentation
+description:
+permalink: /docs/
+---
+<div class="container">
+
+{% include community_row.html
+          title="Language Reference"
+          divId="language-reference"
+          content="Documentation of the Crystal language and compiler features."
+          link_text="crystal-lang.org/reference"
+          url="https://crystal-lang.org/reference"
+          icon="web_asset"
+%}
+
+{% include community_row.html
+          title="API Docs"
+          divId="api"
+          content="Documentation for the Crystal standard-library."
+          link_text="crystal-lang.org/api"
+          url="https://crystal-lang.org/api"
+          icon="web_asset"
+%}
+
+{% include community_row.html
+          title="Installation instructions"
+          divId="install"
+          content="Installation instructions for Crystal."
+          link_text="crystal-lang.org/install"
+          url="/install"
+          icon="web_asset"
+%}
+
+{% include community_row.html
+          title="Media"
+          divId="media"
+          content="Logos and style guide."
+          link_text="crystal-lang.org/media"
+          url="/media"
+          icon="web_asset"
+%}
+
+{% include community_row.html
+          title="Developer Wiki"
+          divId="developer-wiki"
+          content="Developer resources."
+          link_text="GitHub Wiki"
+          url="https://github.com/crystal-lang/crystal/wiki"
+          icon="github"
+          custom_icon="true"
+%}
+
+{% include community_row.html
+          title="Shards documentation"
+          divId="shards"
+          content="Documentation for official shards."
+          link_text="crystal-db"
+          url="http://crystal-lang.github.io/crystal-db/api/latest/"
+%}


### PR DESCRIPTION
This is a draft for an overview page at `/docs` listing several documentation resources, as per https://github.com/crystal-lang/crystal-website/issues/57#issuecomment-451552824

<ins>This is what it looks like</ins> (second iteration)
![image](https://user-images.githubusercontent.com/466378/67943852-4aa13800-fbdb-11e9-85a7-e1b07b53b108.png)

<del>This is what it looks like:</del> (first iteration)

![image](https://user-images.githubusercontent.com/466378/67409821-61340780-f5bb-11e9-894f-b3a6b66473d0.png)

/cc crystal-lang/crystal-book#173