### PR TITLE
Change inline code and links visibility

### DIFF
--- a/_assets/css/_generic.scss
+++ b/_assets/css/_generic.scss
@@ -72,7 +72,7 @@ p > a, td > a, ul:not(#nav-mobile) li > a, dd > a {
 }
 
 p:not(.read-more) {
-  & > a:not(.btn):not(.with-icon) {
+  & > a:not(.gray-link):not(.btn):not(.with-icon) {
     color: #03A9F4;
     border-bottom: 0;
     &:hover {

--- a/_assets/css/_generic.scss
+++ b/_assets/css/_generic.scss
@@ -71,6 +71,17 @@ p > a, td > a, ul:not(#nav-mobile) li > a, dd > a {
   border-bottom: 1px solid $primary-text;
 }
 
+p:not(.read-more) {
+  & > a:not(.btn):not(.with-icon) {
+    color: #03A9F4;
+    border-bottom: 0;
+    &:hover {
+      color: #03A9F4;
+      border-bottom: 1px solid #03A9F4;
+    }
+  }
+}
+
 p.no-underline > a,
 table.no-underline a {
   border-bottom: 0;
@@ -179,7 +190,7 @@ table.no-underline a {
       width: 85%;
     }
   }
-  
+
   @media only screen and (min-width: 993px) {
     #content {
       width: 70%;

--- a/_assets/css/_home.scss
+++ b/_assets/css/_home.scss
@@ -220,8 +220,13 @@
   }
 }
 
-.bountysource-link:hover {
-  text-decoration: underline;
+.bountysource-link {
+  color: #03A9F4;
+  border-bottom: 0;
+  &:hover {
+    color: #03A9F4;
+    border-bottom: 1px solid #03A9F4;
+  }
 }
 
 @media only screen and (max-width: 992px) {

--- a/_assets/css/_pygment_overrides.scss
+++ b/_assets/css/_pygment_overrides.scss
@@ -97,3 +97,8 @@
     }
   }
 }
+
+code.highlighter-rouge {
+  background-color: #E5E5E5;
+  padding: 0 5px;
+}

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ custom_body_classes:
   <div class="row center">
     <div class="col s12">
       <h2 class="latest-release">Latest release <a href="/2020/04/06/crystal-0.34.0-released.html">0.34.0</a></h2>
-      <p>6 April 2020 - <a href="/blog#release_notes">More release notes</a></p>
+      <p>6 April 2020 - <a href="/blog#release_notes" class="gray-link">More release notes</a></p>
     </div>
   </div>
 


### PR DESCRIPTION
Added a 90% grayscale background color to inline code.
Changed paragraph and blog links to #03A9F4 color and only underline when hovered.