### PR TITLE
Remove Bountysource relevance in website

### DIFF
--- a/_assets/css/_home.scss
+++ b/_assets/css/_home.scss
@@ -220,7 +220,7 @@
   }
 }
 
-.bountysource-link {
+.contributing-link {
   color: #03A9F4;
   border-bottom: 0;
   &:hover {

--- a/_includes/sponsors_sidebar.html
+++ b/_includes/sponsors_sidebar.html
@@ -3,7 +3,7 @@
     <h2>Want to become a sponsor?</h2>
     <p>If you like this project and you see its potential, you can help. Every dollar counts!</p>
     <p>
-      <a href="https://salt.bountysource.com/teams/crystal-lang" target="_blank"
+      <a href="https://opencollective.com/crystal-lang" target="_blank"
         class="btn btn-flat btn-large">Donate</a>
     </p>
   </div>
@@ -16,13 +16,14 @@
     <p>
       <h3>What is this list?</h3>
       These are the companies and individuals contributing a monthly amount to help sustain Crystal's development. See
-      the Bountysource campaign for more details.
+      the <a class="contributing-link" href="https://opencollective.com/crystal-lang" target="_blank">Open Collective campaign</a> for more details.
     </p>
 
     <p>
       <h3>I am a sponsor contributing $5/month, but my URL is not listed</h3>
-      We grab the website and avatar from your <a class="bountysource-link" href="https://www.bountysource.com/settings"
-        target="_blank">Bountysource profile</a>. If that fails, we try to use your GitHub or Twitter accounts listed in
+      We grab the website and avatar from your
+      <a class="contributing-link" href="https://opencollective.com" target="_blank">Open Collective profile</a> or your
+      <a class="contributing-link" href="https://www.bountysource.com/settings" target="_blank">Bountysource profile</a>. If that fails, we try to use your GitHub or Twitter accounts listed in
       that same profile.
     </p>
     <p>

--- a/index.html
+++ b/index.html
@@ -11,10 +11,6 @@ custom_body_classes:
       <a href="https://opencollective.com/crystal-lang" target="_blank">
         <img src="{{ 'oc.png' | asset_path }}" class="oc-logo">
       </a>
-      <span> or </span>
-      <a href="https://salt.bountysource.com/teams/crystal-lang" target="_blank">
-        <img src="{{ 'bounty.png' | asset_path }}" class="sponsorship-logo">
-      </a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Take it away from home, and put open collective first in every mention in sponsor and in the Donate button.