### PR TITLE
Reword security section

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -8,7 +8,8 @@ description: There are so many ways to get involved in Crystal. Here's a list of
           title="Security Issues"
           divId="security"
           content="Should you find any security-related issue, please <strong>do not share them openly</strong> in the issue tracker. We have a dedicated mailbox where we keep track of them.<br /><br />
-          You can encrypt your message <a href=\"https://keybase.io/crystal\" target=\"_blank\">via Keybase</a>, or standard PGP (our fingerprint is <code>5995 C83C D754 BE44 8164 1929 0961 7FD3 7CC0 6B54</code>)."
+          You can encrypt your message <a href=\"https://keybase.io/encrypt\" target=\"_blank\">via Keybase</a> (set recipient <code>crystal</code>),
+          or with our <a href=\"http://keys.gnupg.net/pks/lookup?op=get&search=0x09617FD37CC06B54\" target=\"_blank\">PGP key</a> (our fingerprint is <code>5995 C83C D754 BE44 8164 1929 0961 7FD3 7CC0 6B54</code>) and send it to:"
           link_text="security@manas.tech"
           url="mailto:security@manas.tech"
           icon="security"


### PR DESCRIPTION
To encourage sending emails instead of contacting via Keybase.

We should reformat our footer to include links to important sections like this one. Like https://www.rust-lang.org/. @jkicillof what do you think?