### PR TITLE
Drop macOS 10.11 troubleshooting notes

### DIFF
--- a/install/on_mac_os.md
+++ b/install/on_mac_os.md
@@ -24,21 +24,6 @@ brew upgrade crystal
 
 ## Troubleshooting
 
-### On macOS 10.11 (El Capitan)
-
-If you get an error like:
-
-<div class="code_section">{% highlight txt %}
-ld: library not found for -levent
-{% endhighlight txt %}</div>
-
-you need to reinstall the command line tools and then select the default active toolchain:
-
-<div class="code_section">{% highlight bash %}
-xcode-select --install
-xcode-select --switch /Library/Developer/CommandLineTools
-{% endhighlight bash %}</div>
-
 ### On macOS 10.14 (Mojave)
 
 If you get an error like:


### PR DESCRIPTION
Let's not imply 10.11 is supported still in any way when in fact 10.12 is already unsupported (https://github.com/crystal-lang/crystal/issues/9476) and, having been released in 2016, out of its official security maintenance phase already too. Nobody should be using anything older than 10.13.