### PR TITLE
Remove libreadline as recommended library

### DIFF
--- a/install/on_debian.md
+++ b/install/on_debian.md
@@ -35,7 +35,6 @@ sudo apt install libssl-dev      # for using OpenSSL
 sudo apt install libxml2-dev     # for using XML
 sudo apt install libyaml-dev     # for using YAML
 sudo apt install libgmp-dev      # for using Big numbers
-sudo apt install libreadline-dev # for using Readline
 sudo apt install libz-dev        # for using crystal play
 {% endhighlight bash %}</div>
 

--- a/install/on_kubuntu.md
+++ b/install/on_kubuntu.md
@@ -35,7 +35,6 @@ sudo apt install libssl-dev      # for using OpenSSL
 sudo apt install libxml2-dev     # for using XML
 sudo apt install libyaml-dev     # for using YAML
 sudo apt install libgmp-dev      # for using Big numbers
-sudo apt install libreadline-dev # for using Readline
 sudo apt install libz-dev        # for using crystal play
 {% endhighlight bash %}</div>
 

--- a/install/on_ubuntu.md
+++ b/install/on_ubuntu.md
@@ -35,7 +35,6 @@ sudo apt install libssl-dev      # for using OpenSSL
 sudo apt install libxml2-dev     # for using XML
 sudo apt install libyaml-dev     # for using YAML
 sudo apt install libgmp-dev      # for using Big numbers
-sudo apt install libreadline-dev # for using Readline
 sudo apt install libz-dev        # for using crystal play
 {% endhighlight bash %}</div>
 


### PR DESCRIPTION
stlib doesn't use libreadline anymore (https://github.com/crystal-lang/crystal/pull/8364)