### PR TITLE
Remove confusing square brackets around an example path in shell

### DIFF
--- a/install/from_targz.md
+++ b/install/from_targz.md
@@ -11,7 +11,7 @@ Download the file for your platform and uncompress it. Inside it you will have a
 To make it simpler to use, you can create a symbolic link available in the path:
 
 <div class="code_section">{% highlight bash %}
-ln -s [full path to bin/crystal] /usr/local/bin/crystal
+ln -s /full/path/to/bin/crystal /usr/local/bin/crystal
 {% endhighlight bash %}</div>
 
 Then you can invoke the compiler by just typing:


### PR DESCRIPTION
This is motivated by a report from a user who typed in the brackets.