### PR TITLE
Update installer script and installation instructions

### DIFF
--- a/_posts/2020-08-24-announcing-new-apt-and-rpm-repositories.md
+++ b/_posts/2020-08-24-announcing-new-apt-and-rpm-repositories.md
@@ -5,6 +5,9 @@ thumbnail: +
 author: bcardiff
 ---
 
+**UPDATE:** As of 2021-05-01, the bintray repositories are no longer available. The distribution packages are now hosted
+on the Open Build Service, see recent [blog post](https://crystal-lang.org/2021/04/30/new-apt-and-rpm-repositories.html).
+
 We've been working on improving the state of the art of the official deb and rpm repositories.
 
 The main outcome is that we will be able to:

--- a/_posts/2021-04-30-new-apt-and-rpm-repositories.md
+++ b/_posts/2021-04-30-new-apt-and-rpm-repositories.md
@@ -13,7 +13,7 @@ Instead of just hosting the packages, it takes care of the entire build process.
 For now we continue to provide deb and rpm repositories for x86_64 and i686,
 but more platforms and architectures will follow.
 
-All packages are available on OBS at [build.opensuse.org/package/show/devel:languages:crystal](https://build.opensuse.org/package/show/devel:languages:crystal).
+All packages are available on OBS at [build.opensuse.org/package/show/devel:languages:crystal](https://build.opensuse.org/project/show/devel:languages:crystal).
 It offers an [installation page](https://software.opensuse.org/download.html?project=devel%3Alanguages%3Acrystal&package=crystal) with detailed instructions for the many different
 target systems.
 Our own installation instructions at [crystal-lang.org/install](/install) have been updated,

--- a/install.sh
+++ b/install.sh
@@ -106,12 +106,36 @@ _discover_distro_repo() {
       _check_version_id
       DISTRO_REPO="openSUSE_Leap_${VERSION_ID}"
       ;;
-    *)
+    "")
       _error "Unable to identify distribution. You may specify one with environment variable DISTRO_REPO"
       _error "Please, report to https://forum.crystal-lang.org/c/help-support/11"
       exit 1
       ;;
+    *)
+      # If there's no dedicated repository for the distro, try to figure out
+      # if the distro is apt or rpm based and use a default repository.
+      _discover_distro_type
+
+      case "$DISTRO_TYPE" in
+      deb)
+        DISTRO_REPO="Debian_Unstable"
+        ;;
+      rpm)
+        DISTRO_REPO="RHEL_7"
+        ;;
+      *)
+        _error "Unable to identify distribution type ($ID). You may specify a repository with the environment variable DISTRO_REPO"
+        _error "Please, report to https://forum.crystal-lang.org/c/help-support/11"
+        exit 1
+        ;;
+      esac
   esac
+}
+
+_discover_distro_type() {
+  DISTRO_TYPE=""
+  [[ $(command -v apt-get) ]] && DISTRO_TYPE="deb" && return
+  [[ $(command -v yum) ]]     && DISTRO_TYPE="rpm" && return
 }
 
 if [[ $EUID -ne 0 ]]; then
@@ -130,7 +154,6 @@ case $i in
     ;;
     --channel=*)
     CHANNEL="${i#*=}"
-    _warn "Currently, only stable channel is available"
     shift
     ;;
     --help)
@@ -144,12 +167,25 @@ case $i in
 esac
 done
 
+case $CHANNEL in
+  stable)
+    ;;
+  nightly | unstable)
+    OBS_PROJECT="${OBS_PROJECT}:${CHANNEL}"
+    ;;
+  *)
+    _error "Unsupported channel $CHANNEL"
+    exit 1
+    ;;
+esac
+
 if [[ -z "${DISTRO_REPO}" ]]; then
   _discover_distro_repo
 fi
 
 _install_apt() {
   if [[ -z $(command -v wget &> /dev/null) ]] || [[ -z $(command -v gpg &> /dev/null) ]]; then
+    [[ -f /etc/apt/sources.list.d/crystal.list ]] && rm -f /etc/apt/sources.list.d/crystal.list
     apt-get update
     apt-get install -y wget gpg
   fi

--- a/install/on_elementary_os.md
+++ b/install/on_elementary_os.md
@@ -2,4 +2,8 @@
 subtitle: On Elementary OS
 ---
 
+In Elementary OS, you can use the [Official Crystal deb repository](#official-crystal-deb-repository). [Snapcraft](#snapcraft) and [Linuxbrew](#linuxbrew) are also available.
+
+{% include install_from_obs_deb.md %}
 {% include install_from_snapcraft.md distro="elementary" %}
+{% include install_from_linuxbrew.md %}

--- a/install/on_linux_mint.md
+++ b/install/on_linux_mint.md
@@ -2,4 +2,8 @@
 subtitle: On Linux Mint
 ---
 
+On Linux Mint, you can use the [Official Crystal deb repository](#official-crystal-deb-repository). [Snapcraft](#snapcraft) and [Linuxbrew](#linuxbrew) are also available.
+
+{% include install_from_obs_deb.md %}
 {% include install_from_snapcraft.md distro="mint" %}
+{% include install_from_linuxbrew.md %}


### PR DESCRIPTION
Pulls in the updated installer from https://github.com/crystal-lang/distribution-scripts/blob/master/packages/scripts/install.sh and fixes a few details around package install instructions.