### PR TITLE
Store latest release in centralized config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,11 @@ name: The Crystal Programming Language
 description: A compiled language with Ruby like syntax and type inference
 url: https://crystal-lang.org
 logo: /assets/media/crystal_logo.svg
+
+latest_release:
+  version: 1.0.0
+  date: 2021-03-22
+
 defaults:
   -
     scope:

--- a/_includes/sample_dependencies.md
+++ b/_includes/sample_dependencies.md
@@ -8,5 +8,4 @@ crystal: {{ site.latest_release.version }}
 dependencies:
   mysql:
     github: crystal-lang/crystal-mysql
-    version: ~> 0.3.1
 {% endhighlight %}

--- a/_includes/sample_dependencies.md
+++ b/_includes/sample_dependencies.md
@@ -3,7 +3,7 @@ name: my-project
 version: 0.1
 license: MIT
 
-crystal: 0.21.0
+crystal: {{ site.latest_release.version }}
 
 dependencies:
   mysql:

--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@ custom_body_classes:
         <a href="https://crystal-lang.org/reference/getting_started/" target="_blank" class="btn btn-large btn-flat-white">Learn</a>
         <a href="https://play.crystal-lang.org/#/cr" target="_blank" class="btn btn-large btn-flat-white">Try Online</a>
       </p>
-      <h2 class="latest-release">Latest release <a href="/2021/03/22/crystal-1.0-what-to-expect.html">1.0.0</a></h2>
-      <p>22 Mar 2021 - <a href="/blog#release_notes" class="gray-link">More release notes</a></p>
+      <h2 class="latest-release">Latest release <a href="/2021/03/22/crystal-1.0-what-to-expect.html">{{ site.latest_release.version }}</a></h2>
+      <p>{{ site.latest_release.date | date: "%d %B %Y" }} - <a href="/blog#release_notes" class="gray-link">More release notes</a></p>
     </div>
   </div>
 


### PR DESCRIPTION
This patch extracts information about the latest release in a global config value which can be used throughout the site for easier maintenance.

Resolves #115
