### PR TITLE
Removing eventbrite refs

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,9 +12,8 @@
         </div>
         <div class='subtitle' style="margin-bottom: 20px;">{{ page.description }}</div>
         <p class="main-actions">
-          <a href="https://www.eventbrite.com/e/crystal-conference-10-launch-tickets-149153252393" target="_blank" class="btn btn-large btn-flat" style="margin-bottom: 40px;">Get your tickets!</a>
           <a href="/conference" class="btn btn-large btn-flat" style="margin-bottom: 40px;">Agenda</a>
-	</p>
+	      </p>
       {% else %}
         {% if page.url == '/sponsors/' %}
           <div class="row">

--- a/conference/index.html
+++ b/conference/index.html
@@ -3,9 +3,6 @@ title: Crystal 1.0 Conference
 description: >
   July 8th 2021, 12:30pm - 9:30pm UTC
 
-  <p class="main-actions">
-    <a href="https://www.eventbrite.com/e/crystal-conference-10-launch-tickets-149153252393" target="_blank" class="btn btn-large btn-flat">Get your tickets!</a>
-  </p>
 custom_body_classes:
   - main
   - conference
@@ -118,41 +115,11 @@ document.addEventListener('scroll', () => {
 </script>
 <script src="https://d3js.org/d3.v3.min.js"></script>
 
-
-
 <div class="container">
-  <div class="row">
-    <div class="col s12">
-      <h2>Join the Conference on July 8th, 2021</h2>
-      <p class="main-actions">
-        <a href="https://www.eventbrite.com/e/crystal-conference-10-launch-tickets-149153252393" target="_blank" class="btn btn-large btn-flat-white">Get your tickets!</a>
-      </p>
-    </div>
-  </div>
-</div>
-
-<div class="container">
-  <div class="row">
-    <div class="col s12">
-      <h3 id="registration">Registration</h3>
-      <p> Registrations are open. Earlybird tickets are priced at 90 USD until 24 June 2021; after that, tickets will be priced at 120 USD. Once you're registered, you'll receive updates on the speakers and the schedule.
-      </p>
-      <p>
-        Check for community discounts and, if you can’t afford the fee, reach out to <a href="mailto:crystal@manas.tech">crystal@manas.tech</a>.
-      </p>
-    </div>
-  </div>
   <div class="row">
     <div class="col s12">
       <h3 id="time">Time</h3>
-      <p> The conference will take place on Thursday, 8 July 2021, from 12:30 pm to 9:30 pm UTC.
-      </p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col s12">
-      <h3 id="attending">Attending</h3>
-      <p> A link to join the conference video call will be shared with you a few hours before the event - both via email and via this website.
+      <p> The conference took place on Thursday, 8 July 2021, from 12:30 pm to 9:30 pm UTC.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Now that the conference is past us, remove the references to the tickets. I left the banner in the homepage still.