### PR TITLE
Remove `jekyll-timeago`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'jekyll-assets', '~> 2.4.0'
-gem 'jekyll-timeago'
 gem 'jekyll-seo-tag'
 gem 'haml'
 gem 'rouge', git: 'https://github.com/manastech/rouge.git', branch: 'crystal'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,6 @@ GEM
       sass (~> 3.4)
     jekyll-seo-tag (2.7.1)
       jekyll (>= 3.8, < 5.0)
-    jekyll-timeago (0.14.0)
-      mini_i18n (>= 0.8.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.3.1)
@@ -75,7 +73,6 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_i18n (0.8.0)
     mini_portile2 (2.5.0)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
@@ -117,7 +114,6 @@ DEPENDENCIES
   jekyll
   jekyll-assets (~> 2.4.0)
   jekyll-seo-tag
-  jekyll-timeago
   kramdown-parser-gfm
   rouge!
 

--- a/_config.yml
+++ b/_config.yml
@@ -67,7 +67,6 @@ assets:
 plugins:
   - jekyll-seo-tag
   - jekyll-assets
-  - jekyll-timeago
 
 google_calendar_api_key: 'AIzaSyCv-2Npqm0mwmwVCKX8xDPhwtP_8HwCWCE'
 google_calendar_id: '0s0pa4k3fov71e4itn79atlmeg@group.calendar.google.com'

--- a/_includes/blog_row.html
+++ b/_includes/blog_row.html
@@ -6,12 +6,7 @@
           {% img 'authors/{{ author }}.jpg' %}
           <span class="author_name">{{ site.data.blog_authors[author].name }}</span>
           {% if author == authors.last %}
-            {% assign date = include.post.date | timeago %}
-            {% if date contains "month" or date contains "year" %}
-              <span class="date">{{ include.post.date | date_to_string }}</span>
-            {% else %}
-              <span class="date">{{ date }}</span>
-            {% endif %}
+            <span class="date">{{ include.post.date | date_to_string }}</span>
           {% endif %}
         </div>
       {% endfor %}

--- a/_includes/post_header.html
+++ b/_includes/post_header.html
@@ -11,12 +11,7 @@
           {% for author in authors %}
             <span class="author_name">{{ site.data.blog_authors[author].name }}</span>
           {% endfor %}
-          {% assign date = page.date | timeago %}
-          {% if date contains "month" or date contains "year" %}
-            <span class="date">{{ page.date | date_to_string }}</span>
-          {% else %}
-            <span class="date">{{ date }}</span>
-          {% endif %}
+          <span class="date">{{ page.date | date_to_string }}</span>
         </div>
 
         <h1 class='title'>{{ page.title }}</h1>


### PR DESCRIPTION
This plugin provided a tiny detail: Relative descriptions of a posts' publication time (such as `today` or `yesterday`).
It's a nice gimmick, but not an essential feature and the effect for a global audience is questionable (yesterday may be today in another part of the globe).
Most significantly, it also imposes a strong constraint for a static site: The description is relative so it would need to be regenerated regularly in order to keep up to date with the progress of time.

So I think it's best to drop this. I don't expect anyone would miss it.

In any case, this could be implemented much better as a progressive client-side enhancement.

Resolves #52