### PR TITLE
Extract htmlproofer from `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'jekyll-seo-tag'
-gem 'html-proofer'
 gem 'kramdown-parser-gfm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,19 +8,9 @@ GEM
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
-    ethon (0.13.0)
-      ffi (>= 1.15.0)
     eventmachine (1.2.7)
     ffi (1.15.0)
     forwardable-extended (2.6.0)
-    html-proofer (3.19.1)
-      addressable (~> 2.3)
-      mercenary (~> 0.3)
-      nokogumbo (~> 2.0)
-      parallel (~> 1.3)
-      rainbow (~> 3.0)
-      typhoeus (~> 1.3)
-      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -52,18 +42,9 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.5.0)
-    nokogiri (1.11.3)
-      mini_portile2 (~> 2.5.0)
-      racc (~> 1.4)
-    nokogumbo (2.0.5)
-      nokogiri (~> 1.8, >= 1.8.4)
-    parallel (1.20.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
-    racc (1.5.2)
-    rainbow (3.0.0)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -75,15 +56,11 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    typhoeus (1.4.0)
-      ethon (>= 0.9.0)
-    yell (2.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer
   jekyll
   jekyll-seo-tag
   kramdown-parser-gfm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 OUTPUT_DIR ?= _site
 
+htmlproofer = vendor/bin/htmlproofer
+
 .PHONY: build
 build: $(OUTPUT_DIR)
 
@@ -7,8 +9,8 @@ $(OUTPUT_DIR):
 	bundle exec jekyll build --destination $(OUTPUT_DIR)
 
 .PHONY: check_html
-check_html: $(OUTPUT_DIR)
-	htmlproofer $(OUTPUT_DIR) \
+check_html: $(OUTPUT_DIR) $(htmlproofer)
+	$(htmlproofer) $(OUTPUT_DIR) \
 		--assume-extension \
 		--url-swap "\A\/(images):https://crystal-lang.org/\1" \
 		--disable_external \
@@ -17,13 +19,16 @@ check_html: $(OUTPUT_DIR)
 		--check-img-http
 
 .PHONY: check_external_links
-check_external_links: $(OUTPUT_DIR)
-	htmlproofer $(OUTPUT_DIR) \
+check_external_links: $(OUTPUT_DIR) $(htmlproofer)
+	$(htmlproofer) $(OUTPUT_DIR) \
 		--assume-extension \
 		--url-swap "\A\/(api|docs|images|reference):https://crystal-lang.org/\1" \
 		--url-ignore "http://0.0.0.0:8080" \
 		--http-status-ignore 999 \
 		--external_only
+
+$(htmlproofer):
+	gem install html-proofer --bindir $(dir $@)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
htmlproofer is independent of the Jekyll setup, so we should not merge its dependencies