### PR TITLE
Refactor layouts

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: page
 title: Page not found
 description: "The requested URL doesn't exist. Meet the Crystal programming language at https://crystal-lang.org/"
 custom_body_classes:

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ defaults:
       type: pages
     values:
       image: /assets/icon.png
-      layout: default
+      layout: page
   -
     scope:
       path: ""

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,8 +1,0 @@
-<div class="top-banner">
-  <a href="https://www.eventbrite.co.uk/e/raw-crystal-2020-tickets-127439094763" target="_blank">
-    <span class="tb-title">RAW CRYSTAL<span class="tb-thin"> | 2020</span></span>
-    <span class="tb-gap"></span>
-    <span class="tb-date">Dec 11</span>
-    <span class="tb-register">REGISTER AT <em>Eventbrite</em></span>
-  </a>
-</div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,40 +1,17 @@
 <div class='header-section valign-wrapper no-select'>
-  {% if page.url == "/" or page.url == "/conference/"%}<div id="delaunay"></div>{% endif %}
+  {% if page.header.delaunay %}<div id="delaunay"></div>{% endif %}
   <div id='content'>
     <div class='valign center-align'>
-      {% if page.url == "/" %}
-        <div class='brand-logo' id='logo-container'>
-          <canvas height='300' id='logo-canvas' style='cursor:move' width='300'></canvas>
+      <div class="row">
+        <div class="col offset-m1 m10 s12">
+          <h1 class='title'>{{ include.header_title | default: page.title }}</h1>
         </div>
-        <div id="crystal-container">
-          <svg id="Crystal" data-name="Crystal" height="42" width="230" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 230 42"><title>crystal</title><path d="M27.93,34.73l.64,5.45a42,42,0,0,1-12.29,1.51q-9,0-12.63-4.64T0,21Q0,9.58,3.65,4.95T16.28.31A45.27,45.27,0,0,1,27.76,1.59l-.69,5.51q-5-.4-10.78-.41-5,0-6.81,3T7.65,21q0,8.23,1.82,11.27t6.81,3A91.36,91.36,0,0,0,27.93,34.73ZM64.79,41H57.08l-3.19-12.4A4.51,4.51,0,0,0,49.26,25l-7.18-.06V41H34.88V1Q40,.48,49.43.49,57,.49,60.18,3t3.16,9.19q0,4.63-1.74,7.1t-5.74,3v.29a7,7,0,0,1,3.25,1.85,7.82,7.82,0,0,1,2.09,4.06ZM42.07,19h7.18q3.88-.06,5.3-1.39t1.42-5Q56,9,54.56,7.73t-5.3-1.28H42.07Zm44.74,8.46V41H79.56V27.37L66.41,1h7.65l7.3,15.53q.4.93,1.62,4.81h.46q1.22-3.88,1.62-4.81L92.37,1H99.9Zm32-2.32-8.06-2.55a11.15,11.15,0,0,1-6.2-4.2A13.22,13.22,0,0,1,102.69,11q0-6.55,3-8.64T116.42.31A51.36,51.36,0,0,1,129,1.65l-.46,5.16q-6.6-.23-11.88-.23-4,0-5.33.78T110,11.15a5.07,5.07,0,0,0,1,3.51,8.38,8.38,0,0,0,3.51,1.82l7.71,2.38q4.58,1.45,6.4,4.26a13.37,13.37,0,0,1,1.83,7.39q0,6.61-3.13,8.9t-11.07,2.29a66.11,66.11,0,0,1-13-1.27l.46-5.33q10.14.23,12.69.23,4,0,5.33-.93T123,30.45a5.31,5.31,0,0,0-.9-3.54A7.64,7.64,0,0,0,118.8,25.17ZM166,7.21H153.68V41h-7.3V7.21H134.15V1H166Zm23.76,22.49H174.95L171.65,41h-7.42l12-38.07A2.43,2.43,0,0,1,178.83,1h7.07a2.43,2.43,0,0,1,2.61,1.91l12,38.07h-7.42Zm-1.74-6L184,9.93q-.81-3.13-.87-3.42h-1.56l-.93,3.42-4,13.79ZM212.38,1V31.66a3.52,3.52,0,0,0,.75,2.58,3.83,3.83,0,0,0,2.66.72h13.91l.29,5.62q-5.68.52-15.88.52-9,0-9-8.29V1Z"/></svg>
-	      </div>
-        <div class='subtitle' style="margin-bottom: 20px;">{{ page.description }}</div>
-        <p class="main-actions">
-          <a href="/install/" class="btn btn-large btn-flat">Install</a>
-          <a href="https://crystal-lang.org/reference/getting_started/" target="_blank" class="btn btn-large btn-flat">Learn</a>
-          <a href="https://play.crystal-lang.org/#/cr" target="_blank" class="btn btn-large btn-flat">Try Online</a>
-	      </p>
-      {% else %}
-        {% if page.url == '/sponsors/' %}
-          <div class="row">
-            <div class="col offset-m1 m10 s12">
-              <h1 class='title'>{{ site.data.sponsors.size }}+ {{ page.title }}</h1>
-            </div>
-          </div>
-        {% else %}
-        <div class="row">
-          <div class="col offset-m1 m10 s12">
-            <h1 class='title'>{{ page.title }}</h1>
-          </div>
+      </div>
+      <div class="row">
+        <div class="col offset-m1 m10 s12">
+          <div class='subtitle'>{{ page.description }}</div>
         </div>
-        {% endif %}
-        <div class="row">
-          <div class="col offset-m1 m10 s12">
-            <div class='subtitle'>{{ page.description }}</div>
-          </div>
-        </div>
-        {% endif %}
+      </div>
     </div>
   </div>
 </div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,0 +1,12 @@
+---
+layout: skeleton
+# Base layout with site-specific framing: Top nav and footer
+# Inheriting layouts implement the page header and content.
+---
+<div class="wrapper {{ page.custom_body_classes | join: ' '}}">
+  {% include nav.html %}
+
+  {{ content }}
+
+  {% include footer.html %}
+</div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,27 @@
+---
+layout: base
+# Layout for home page with special header
+---
+<div class='header-section valign-wrapper no-select'>
+  <div id="delaunay"></div>
+  <div id='content'>
+    <div class='valign center-align'>
+      <div class='brand-logo' id='logo-container'>
+        <canvas height='300' id='logo-canvas' style='cursor:move' width='300'></canvas>
+      </div>
+      <div id="crystal-container">
+        <svg id="Crystal" data-name="Crystal" height="42" width="230" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 230 42"><title>crystal</title><path d="M27.93,34.73l.64,5.45a42,42,0,0,1-12.29,1.51q-9,0-12.63-4.64T0,21Q0,9.58,3.65,4.95T16.28.31A45.27,45.27,0,0,1,27.76,1.59l-.69,5.51q-5-.4-10.78-.41-5,0-6.81,3T7.65,21q0,8.23,1.82,11.27t6.81,3A91.36,91.36,0,0,0,27.93,34.73ZM64.79,41H57.08l-3.19-12.4A4.51,4.51,0,0,0,49.26,25l-7.18-.06V41H34.88V1Q40,.48,49.43.49,57,.49,60.18,3t3.16,9.19q0,4.63-1.74,7.1t-5.74,3v.29a7,7,0,0,1,3.25,1.85,7.82,7.82,0,0,1,2.09,4.06ZM42.07,19h7.18q3.88-.06,5.3-1.39t1.42-5Q56,9,54.56,7.73t-5.3-1.28H42.07Zm44.74,8.46V41H79.56V27.37L66.41,1h7.65l7.3,15.53q.4.93,1.62,4.81h.46q1.22-3.88,1.62-4.81L92.37,1H99.9Zm32-2.32-8.06-2.55a11.15,11.15,0,0,1-6.2-4.2A13.22,13.22,0,0,1,102.69,11q0-6.55,3-8.64T116.42.31A51.36,51.36,0,0,1,129,1.65l-.46,5.16q-6.6-.23-11.88-.23-4,0-5.33.78T110,11.15a5.07,5.07,0,0,0,1,3.51,8.38,8.38,0,0,0,3.51,1.82l7.71,2.38q4.58,1.45,6.4,4.26a13.37,13.37,0,0,1,1.83,7.39q0,6.61-3.13,8.9t-11.07,2.29a66.11,66.11,0,0,1-13-1.27l.46-5.33q10.14.23,12.69.23,4,0,5.33-.93T123,30.45a5.31,5.31,0,0,0-.9-3.54A7.64,7.64,0,0,0,118.8,25.17ZM166,7.21H153.68V41h-7.3V7.21H134.15V1H166Zm23.76,22.49H174.95L171.65,41h-7.42l12-38.07A2.43,2.43,0,0,1,178.83,1h7.07a2.43,2.43,0,0,1,2.61,1.91l12,38.07h-7.42Zm-1.74-6L184,9.93q-.81-3.13-.87-3.42h-1.56l-.93,3.42-4,13.79ZM212.38,1V31.66a3.52,3.52,0,0,0,.75,2.58,3.83,3.83,0,0,0,2.66.72h13.91l.29,5.62q-5.68.52-15.88.52-9,0-9-8.29V1Z"/></svg>
+      </div>
+      <div class='subtitle' style="margin-bottom: 20px;">{{ page.description }}</div>
+      <p class="main-actions">
+        <a href="/install/" class="btn btn-large btn-flat">Install</a>
+        <a href="https://crystal-lang.org/reference/getting_started/" target="_blank" class="btn btn-large btn-flat">Learn</a>
+        <a href="https://play.crystal-lang.org/#/cr" target="_blank" class="btn btn-large btn-flat">Try Online</a>
+      </p>
+    </div>
+  </div>
+</div>
+
+<main>
+  {{ content }}
+</main>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,5 +1,6 @@
 ---
 layout: base
+site_title: The Crystal Programming Language
 # Layout for home page with special header
 ---
 <div class='header-section valign-wrapper no-select'>

--- a/_layouts/install.html
+++ b/_layouts/install.html
@@ -1,5 +1,6 @@
 ---
 layout: base
+page_title: Install {{page.subtitle}}
 # Layout for pages in the install section
 # Differs from page layout by omitting the header (there is a special header)
 ---

--- a/_layouts/install.html
+++ b/_layouts/install.html
@@ -1,21 +1,25 @@
 ---
-layout: default
+layout: base
+# Layout for pages in the install section
+# Differs from page layout by omitting the header (there is a special header)
 ---
-<div class="container install">
-  <h1 class="center"><a href="/install">Install</a></h1>
-  <h1 class="distro-title">{{ page.subtitle }}</h1>
-  <div class="row">
-    <div class="col offset-m1 m10 s12">
-      {{ content }}
+<main>
+  <div class="container install">
+    <h1 class="center"><a href="/install">Install</a></h1>
+    <h1 class="distro-title">{{ page.subtitle }}</h1>
+    <div class="row">
+      <div class="col offset-m1 m10 s12">
+        {{ content }}
+      </div>
     </div>
   </div>
-</div>
-<hr class="hr-light">
-<div class="done-install">
-  <h1>Done installing?</h1>
-  <a href="https://crystal-lang.org/reference/getting_started/" target="_blank" class="btn btn-large btn-flat">Learn</a>
+  <hr class="hr-light">
+  <div class="done-install">
+    <h1>Done installing?</h1>
+    <a href="https://crystal-lang.org/reference/getting_started/" target="_blank" class="btn btn-large btn-flat">Learn</a>
 
-  <h2>Found any issues?</h2>
-  <a href="https://forum.crystal-lang.org/c/help-support" target="_blank" class="btn btn-large btn-flat">Forum
-    support</a>.
-</div>
+    <h2>Found any issues?</h2>
+    <a href="https://forum.crystal-lang.org/c/help-support" target="_blank" class="btn btn-large btn-flat">Forum
+      support</a>.
+  </div>
+</main>

--- a/_layouts/markdown.html
+++ b/_layouts/markdown.html
@@ -1,4 +1,0 @@
----
-layout: default
----
-{{ content }}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,9 @@
+---
+layout: base
+# Generic layout for pages, including page header and body
+---
+{% include header.html %}
+
+<main>
+  {{ content }}
+</main>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,57 +1,63 @@
 ---
-layout: default
+layout: base
+# Layout for blog posts including post header and body
+# Doesn't use the page layout because posts have a special header
 ---
-<div class="container">
-  <div class="row post-layout">
-    <div class="col m2 share">
-      <p class="title small share-title">Share</p>
-      <div class="share-list">
-        {% assign share_url = site.url | append: page.url | cgi_escape %}
-        <a href="https://twitter.com/intent/tweet?url={{ share_url }}&text={{ page.title | cgi_escape }}&via=CrystalLanguage" target="_blank">
-          <div class="share-item"><i class="extra-icons twitter gray"></i></div>
-        </a>
-        <a href="https://www.facebook.com/sharer/sharer.php?u={{ share_url }}" target="_blank">
-          <div class="share-item"><i class="extra-icons facebook gray"></i></div>
-        </a>
-        <a href="https://plus.google.com/share?url={{ share_url }}" target="_blank">
-          <div class="share-item"><i class="extra-icons google_plus gray"></i></div>
+{% include post_header.html %}
+
+<main>
+  <div class="container">
+    <div class="row post-layout">
+      <div class="col m2 share">
+        <p class="title small share-title">Share</p>
+        <div class="share-list">
+          {% assign share_url = site.url | append: page.url | cgi_escape %}
+          <a href="https://twitter.com/intent/tweet?url={{ share_url }}&text={{ page.title | cgi_escape }}&via=CrystalLanguage" target="_blank">
+            <div class="share-item"><i class="extra-icons twitter gray"></i></div>
           </a>
+          <a href="https://www.facebook.com/sharer/sharer.php?u={{ share_url }}" target="_blank">
+            <div class="share-item"><i class="extra-icons facebook gray"></i></div>
+          </a>
+          <a href="https://plus.google.com/share?url={{ share_url }}" target="_blank">
+            <div class="share-item"><i class="extra-icons google_plus gray"></i></div>
+            </a>
+        </div>
       </div>
+
+      <div class="col s12 m9">
+        {{ content }}
+      </div>
+      <div class="col m1"></div>
     </div>
 
-    <div class="col s12 m9">
-      {{ content }}
+    <div class="row disqus">
+      <div class="col m2"></div>
+      <div class="col s12 m9" id='disqus_thread'>
+        {{ content }}
+      </div>
+      <div class="col m1"></div>
     </div>
-    <div class="col m1"></div>
   </div>
+  <script>
+    /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+    var disqus_shortname = 'crystal-lang'; // required: replace example with your forum shortname
+    var disqus_identifier = '{{ page.id }}';
+    var disqus_title = {{ page.title | jsonify }};
+    var disqus_url = "http://crystal-lang.org/{{ page.url }}";
 
-  <div class="row disqus">
-    <div class="col m2"></div>
-    <div class="col s12 m9" id='disqus_thread'>
-      {{ content }}
-    </div>
-    <div class="col m1"></div>
-  </div>
-</div>
-<script>
-  /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-  var disqus_shortname = 'crystal-lang'; // required: replace example with your forum shortname
-  var disqus_identifier = '{{ page.id }}';
-  var disqus_title = {{ page.title | jsonify }};
-  var disqus_url = "http://crystal-lang.org/{{ page.url }}";
-
-  /* * * DON'T EDIT BELOW THIS LINE * * */
-  (function() {
-      var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-  })();
-</script>
-<noscript>
-  Please enable JavaScript to view the
-  <a href='http://disqus.com/?ref_noscript'>comments powered by Disqus.</a>
-</noscript>
-<a class='dsq-brlink' href='http://disqus.com'>
-  comments powered by
-  <span class='logo-disqus'>Disqus</span>
-</a>
+    /* * * DON'T EDIT BELOW THIS LINE * * */
+    (function() {
+        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    })();
+  </script>
+  <noscript>
+    Please enable JavaScript to view the
+    <a href='http://disqus.com/?ref_noscript'>comments powered by Disqus.</a>
+  </noscript>
+  <a class='dsq-brlink' href='http://disqus.com'>
+    comments powered by
+    <span class='logo-disqus'>Disqus</span>
+  </a>
+</main>

--- a/_layouts/skeleton.html
+++ b/_layouts/skeleton.html
@@ -5,7 +5,12 @@ layout: none
 <!DOCTYPE html>
 <html lang='en'>
   <head>
-    <title>{% if page.url != '/' %}{% unless page.layout == "install" %}{{ page.title }}{% else %}Install {{page.subtitle}}{% endunless %} - {% endif %}The Crystal Programming Language
+    <title>
+      {%- if layout.site_title -%}
+        {{ layout.site_title}}
+      {%- else -%}
+        {{ layout.page_title | liquify | default: page.title }} - The Crystal Programming Language
+      {%- endif -%}
     </title>
     <meta charset='utf-8'>
     <!-- Import Google Icon Font -->

--- a/_layouts/skeleton.html
+++ b/_layouts/skeleton.html
@@ -1,3 +1,7 @@
+---
+layout: none
+# Basic HTML skeleton with only the top nav and otherwise blank content
+---
 <!DOCTYPE html>
 <html lang='en'>
   <head>
@@ -16,22 +20,7 @@
     <script src='https://code.jquery.com/jquery-3.1.1.min.js' type='text/javascript'></script>
   </head>
   <body>
-    <!-- {% include banner.html %} -->
-    <div class="wrapper {{page.custom_body_classes | join: ' '}}">
-      {% include nav.html %}
-      {% unless page.layout == "install" %}
-        {% if page.is_post or page.collection == 'releases' %}
-          {% include post_header.html %}
-        {% else %}
-          {% include header.html %}
-        {% endif %}
-      {% endunless %}
-
-      <main>
-        {{ content }}
-      </main>
-      {% include footer.html %}
-    </div>
+    {{ content }}
 
     <script id="dsq-count-scr" src="//crystal-lang.disqus.com/count.js" async></script>
     <script src="/assets/js/bundle.js"></script>

--- a/_plugins/liquify.rb
+++ b/_plugins/liquify.rb
@@ -1,0 +1,7 @@
+module LiquidFilter
+  def liquify(input)
+    Liquid::Template.parse(input).render(@context)
+  end
+end
+
+Liquid::Template.register_filter(LiquidFilter)

--- a/conference/index.html
+++ b/conference/index.html
@@ -6,6 +6,8 @@ description: >
 custom_body_classes:
   - main
   - conference
+header:
+  delaunay: true
 ---
 
 <div class="container">

--- a/feed.xml
+++ b/feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: null
+layout: none
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 title: Crystal
 description: A language for humans and computers
+layout: home
 custom_body_classes:
 - main
 ---

--- a/install/index.html
+++ b/install/index.html
@@ -1,8 +1,8 @@
 ---
 title: Install
 description: You can install Crystal in different ways. Select your platform to find specific instructions.
-layout: default
 permalink: /install/
+layout: page
 ---
 <div class="container">
   <div class="row">

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -1,7 +1,14 @@
 ---
 title: Sponsors
 description: These are the companies and individuals that help sustain Crystal's development.
+layout: skeleton
 ---
+{% capture header_title %}{{ site.data.sponsors.size }}+ {{ page.title }}{% endcapture %}
+
+{% include header.html header_title=header_title %}
+
+<main>
+
 <script src='/javascripts/tablesort-5.2.1/tablesort.js'></script>
 <script src='/javascripts/tablesort-5.2.1/sorts/tablesort.number.js'></script>
 <script src='/javascripts/tablesort-5.2.1/sorts/tablesort.date.js'></script>
@@ -78,3 +85,6 @@ description: These are the companies and individuals that help sustain Crystal's
 <script>
   new Tablesort(document.getElementById('sponsors-tbl'));
 </script>
+
+</main>
+{% include footer.html %}


### PR DESCRIPTION
This patch refactors the layouts and header includes of the website for a more organized structure.

The main objective is to remove page-specific behaviour from `_layouts/default.html` and `_includes/header.html`. This configuration should not be hidden in generic layouts/includes and instead be driven from the pages directly.

To achieve this, a couple additional layouts are introduced, which leaves us with the following layout strucuture:

* `skeleton`: Basic HTML skeleton with only the top nav and otherwise blank content.
  * `base`: Base layout with site-specific framing: Top nav and footer
    * `page`: Generic layout for pages, including regular header and page content
    * `post`: Layout for blog posts including post header and body
    * `install`: Layout for pages in the install section
    * `home`: Layout for home page (with special header)

This is an internal change only. The generated result is identical (except for some whitespace changes).