### PR TITLE
Fix layout for sponsors page

### DIFF
--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -1,7 +1,7 @@
 ---
 title: Sponsors
 description: These are the companies and individuals that help sustain Crystal's development.
-layout: skeleton
+layout: base
 ---
 {% capture header_title %}{{ site.data.sponsors.size }}+ {{ page.title }}{% endcapture %}
 
@@ -87,4 +87,3 @@ layout: skeleton
 </script>
 
 </main>
-{% include footer.html %}


### PR DESCRIPTION
Fixup for #251. The refactor used a wrong layout for the sponsors page which made it miss the site header. This patch fixes that.