### PR TITLE
Add page with living style guide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,8 @@ future: true
 collections:
   releases:
     output: true
+  style_guide:
+    output: false
 
 defaults:
   -
@@ -65,3 +67,4 @@ kramdown:
     block:
       css_class: code_section
 
+repository: crystal-lang/crystal-website

--- a/_includes/style-guide/component.html
+++ b/_includes/style-guide/component.html
@@ -11,8 +11,8 @@
   </div>
   <div class="styleguide__code">
 
-{% highlight html %}
-{{ component.content }}
+{% highlight markdown %}
+{% include_relative {{ component.path }} %}
 {% endhighlight %}
 
   </div>

--- a/_includes/style-guide/component.html
+++ b/_includes/style-guide/component.html
@@ -1,0 +1,19 @@
+<article class="styleguide">
+  <header class="styleguide__header">
+    <h3 id="guide-{{ component.title | slugify }}">{{ component.title }}</h3>
+      {% if component.usage %}<p><strong>Usage:</strong> {{ component.usage }}</p>{% endif %}
+      {% if component.module %}<p><strong>Include partial:</strong> <a href="https://github.com{{ site.repository | prepend: '/' | append: '/blob/master/' }}{{ component.module }}"><code>{{ component.module }}</code></a></p>{% endif %}
+      {% if component.scss %}<p class="styleguide--last"><strong>SCSS partial:</strong> <a href="https://github.com{{ site.repository | prepend: '/' | append: '/blob/master/' }}{{ component.scss }}">{{ component.scss }}</a></p>{% endif %}
+  </header>
+
+  <div class="styleguide__rendered post-layout">
+    {{ component.content }}
+  </div>
+  <div class="styleguide__code">
+
+{% highlight html %}
+{{ component.content }}
+{% endhighlight %}
+
+  </div>
+</article>

--- a/_sass/pages/style-guide.scss
+++ b/_sass/pages/style-guide.scss
@@ -1,0 +1,79 @@
+.wrapper > main > h2 {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.styleguide {
+  display: grid;
+  grid-template-areas: "head     code"
+                       "rendered code";
+  grid-template-columns: 50% 50%;
+  grid-template-rows: auto 1fr;
+
+  @media(max-width: 1200px) {
+    grid-template-areas: "head"
+                         "rendered";
+
+    grid-template-columns: 1fr;
+    &__code {
+      display: none;
+    }
+  }
+
+  border-top: 2px solid #000;
+
+  &__header {
+    padding: 1.5em;
+    grid-area: head;
+
+    h3 {
+      margin-top: 0 !important;
+    }
+
+    p {
+      margin-top: 0;
+
+      a {
+        border-bottom-width: 0;
+      }
+
+      &.entry--last {
+        margin-bottom: 1em;
+      }
+    }
+  }
+
+  &__rendered {
+    grid-area: rendered;
+    padding: 1.5em;
+  }
+
+  &__code {
+    grid-area: code;
+    clear: both;
+    position: relative;
+
+    background-color: #f4f4f4;
+    padding: 1.5em;
+
+    > figure {
+      margin-top: 0;
+    }
+
+    > .highlight {
+      border: none;
+      padding: 0;
+      font-size: .9em;
+
+      &, > :first-child {
+        &::before, &::after {
+          content: none;
+        }
+      }
+    }
+
+    pre {
+      white-space: pre-line;
+    }
+  }
+}

--- a/_sass/stylesheet.scss
+++ b/_sass/stylesheet.scss
@@ -38,4 +38,5 @@ $codeFont:      'Roboto Mono', monospace;
         "conference",
         "pygment_overrides",
         "error",
-        "home";
+        "home",
+        "pages/style-guide";

--- a/_style_guide/blog-post-teaser.md
+++ b/_style_guide/blog-post-teaser.md
@@ -1,0 +1,14 @@
+---
+title: Post Teaser
+type: blog
+module: _includes/blog_row.html
+post:
+  title: Installing specific versions of Crystal's binary packages
+  author: straight-shoota
+  summary: Binary packages are now available for older releases on the Open Build Service
+  date: 2021-08-13
+  id: /2021/08/13/install-specific-versions
+  url: /2021/08/13/install-specific-versions.html
+---
+
+{% include blog_row.html post=page.post %}

--- a/_style_guide/elements_team-member.md
+++ b/_style_guide/elements_team-member.md
@@ -1,0 +1,18 @@
+---
+title: Team Member
+type: elements
+---
+<div class="team-member">
+            <img src="/assets/authors/asterite.jpg">
+            <div class="team-member__inner">
+              <span class="member_name">Ary Borenzweig</span>
+              <span class="handles">
+                <span class="github_handle"><a href="https://github.com/asterite" title="GitHub profile"><i class="extra-icons github"></i> asterite</a></span>
+                <span class="forum_handle"><a href="https://forum.crystal-lang.org/u/asterite" title="Crystal Forum profile"><i class="material-icons">forum</i> asterite</a></span>
+              </span>
+
+                <span class="member_role">Co-Creator, Steering Council</span>
+
+
+            </div>
+          </div>

--- a/_style_guide/elements_team-member.md
+++ b/_style_guide/elements_team-member.md
@@ -3,16 +3,13 @@ title: Team Member
 type: elements
 ---
 <div class="team-member">
-            <img src="/assets/authors/asterite.jpg">
-            <div class="team-member__inner">
-              <span class="member_name">Ary Borenzweig</span>
-              <span class="handles">
-                <span class="github_handle"><a href="https://github.com/asterite" title="GitHub profile"><i class="extra-icons github"></i> asterite</a></span>
-                <span class="forum_handle"><a href="https://forum.crystal-lang.org/u/asterite" title="Crystal Forum profile"><i class="material-icons">forum</i> asterite</a></span>
-              </span>
-
-                <span class="member_role">Co-Creator, Steering Council</span>
-
-
-            </div>
-          </div>
+  <img src="/assets/authors/asterite.jpg">
+  <div class="team-member__inner">
+    <span class="member_name">Ary Borenzweig</span>
+    <span class="handles">
+      <span class="github_handle"><a href="https://github.com/asterite" title="GitHub profile"><i class="extra-icons github"></i> asterite</a></span>
+      <span class="forum_handle"><a href="https://forum.crystal-lang.org/u/asterite" title="Crystal Forum profile"><i class="material-icons">forum</i> asterite</a></span>
+    </span>
+    <span class="member_role">Co-Creator, Steering Council</span>
+  </div>
+</div>

--- a/_style_guide/typography-basics.md
+++ b/_style_guide/typography-basics.md
@@ -1,0 +1,15 @@
+---
+title: Basics
+type: typography
+---
+
+**Crystal’s** syntax is *heavily* inspired by [Ruby’s](https://ruby-lang.org/).
+
+So it feels natural to read and ***easy*** to write, and has the added benefit of
+a lower learning curve for experienced Ruby devs: `cat [crystal](https://) > /dev/brain`.
+
+The **slick** syntax makes it easy to `read` for humans, but it's also [**fast** on machines](/).
+
+On [the *Crystal Forum* you can meet `humans` interested in Crystal](https://forum.crystal-lang.org).
+
+Press <kbd>Ctr+C</kbd> to end the process.

--- a/_style_guide/typography-blockquote.md
+++ b/_style_guide/typography-blockquote.md
@@ -1,0 +1,12 @@
+---
+title: Blockquotes
+type: typography
+---
+
+> Thank you! [Crystal](https://crystal-lang.org) is awesome!
+
+> I am always happy to read the release notes. Awesome work, guys!
+
+> We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements. For more details, visit the [changelog](https://github.com/crystal-lang/crystal/releases/tag/1.3.0). Breaking changes are marked with ⚠️.
+
+> `Multi assign = heaven`.

--- a/_style_guide/typography-code-block.md
+++ b/_style_guide/typography-code-block.md
@@ -1,0 +1,45 @@
+---
+title: Code Block
+type: typography
+---
+
+```crystal
+# A very basic HTTP server
+require "http/server"
+
+server = HTTP::Server.new do |context|
+  context.response.content_type = "text/plain"
+  context.response.print "Hello world, got #{context.request.path}!"
+end
+
+puts "Listening on http://127.0.0.1:8080"
+server.listen(8080)
+```
+
+```yaml
+name: my-project
+version: 0.1
+license: MIT
+
+crystal: 1.3.0
+
+dependencies:
+  mysql:
+    github: crystal-lang/crystal-mysql
+```
+
+All types are non-nilable in Crystal, and nilable variables are represented as a union between the type and nil.
+
+```
+if rand(2) > 0
+  my_string = "hello world"
+end
+
+puts my_string.upcase
+```
+
+```terminal
+$ crystal build hello-world.cr
+$ ./hello-world
+Hello World!
+```

--- a/_style_guide/typography-figure.md
+++ b/_style_guide/typography-figure.md
@@ -1,0 +1,16 @@
+---
+title: Figure
+type: typography
+---
+
+<figure>
+  {% highlight crystal %}
+  tmp = some_exp1
+  if tmp
+    tmp
+  else
+    some_exp2
+  end
+  {% endhighlight %}
+  <label>Crystal code</label>
+</figure>

--- a/_style_guide/typography-headline.md
+++ b/_style_guide/typography-headline.md
@@ -1,0 +1,38 @@
+---
+title: Headlines
+type: typography
+---
+
+# Headline 1
+
+## Headline 2
+
+### Headline 3
+
+#### Headline 4
+
+##### Headline 5
+
+###### Headline 6
+
+# Headline 1
+
+We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements.
+
+## Headline 2
+
+We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements.
+
+### Headline 3
+
+We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements.
+
+#### Headline 4
+
+We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements.
+
+##### Headline 5
+
+We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements.
+
+###### Headline 6

--- a/_style_guide/typography-list-definition.md
+++ b/_style_guide/typography-list-definition.md
@@ -1,0 +1,9 @@
+---
+title: Definition List
+type: typography
+---
+
+<dl>
+  <dt>Crystal</dt><dd>Language</dd>
+  <dt>Shards</dt><dd>Dependency Manager</dd>
+</dl>

--- a/_style_guide/typography-list-ordered.md
+++ b/_style_guide/typography-list-ordered.md
@@ -1,0 +1,17 @@
+---
+title: Ordered List
+type: typography
+---
+
+* Fast as C
+* Slick as Ruby
+* Crystal uses [green threads](/), called fibers, to achieve concurrency. Fibers communicate with each other using channels, as in Go or Clojure, without   having to turn to shared memory or locks.
+* Crystal libraries are packed as Shards, and distributed via Git without needing a centralised repository.
+
+  Built in commands allow dependencies to be easily specified through a YAML file and fetched from their respective repositories.
+* ```text
+  Crystal 1.3.0 (2022-01-06)
+
+  LLVM: 13.0.0
+  Default target: x86_64-unknown-linux-gnu
+  ```

--- a/_style_guide/typography-list-ordered.md
+++ b/_style_guide/typography-list-ordered.md
@@ -3,15 +3,15 @@ title: Ordered List
 type: typography
 ---
 
-* Fast as C
-* Slick as Ruby
-* Crystal uses [green threads](/), called fibers, to achieve concurrency. Fibers communicate with each other using channels, as in Go or Clojure, without   having to turn to shared memory or locks.
-* Crystal libraries are packed as Shards, and distributed via Git without needing a centralised repository.
+1. Fast as C
+2. Slick as Ruby
+3. Crystal uses [green threads](/), called fibers, to achieve concurrency. Fibers communicate with each other using channels, as in Go or Clojure, without   having to turn to shared memory or locks.
+4. Crystal libraries are packed as Shards, and distributed via Git without needing a centralised repository.
 
-  Built in commands allow dependencies to be easily specified through a YAML file and fetched from their respective repositories.
-* ```text
-  Crystal 1.3.0 (2022-01-06)
+   Built in commands allow dependencies to be easily specified through a YAML file and fetched from their respective repositories.
+5. ```text
+   Crystal 1.3.0 (2022-01-06)
 
-  LLVM: 13.0.0
-  Default target: x86_64-unknown-linux-gnu
-  ```
+   LLVM: 13.0.0
+   Default target: x86_64-unknown-linux-gnu
+   ```

--- a/_style_guide/typography-list-unordered.md
+++ b/_style_guide/typography-list-unordered.md
@@ -1,0 +1,8 @@
+---
+title: Unordered List
+type: typography
+---
+
+1. Run `shards install`
+2. [Run `crystal spec`](https://crystal-lang.org/)
+3. Run `crystal --version`

--- a/_style_guide/typography-list-unordered.md
+++ b/_style_guide/typography-list-unordered.md
@@ -3,6 +3,15 @@ title: Unordered List
 type: typography
 ---
 
-1. Run `shards install`
-2. [Run `crystal spec`](https://crystal-lang.org/)
-3. Run `crystal --version`
+* Fast as C
+* Slick as Ruby
+* Crystal uses [green threads](/), called fibers, to achieve concurrency. Fibers communicate with each other using channels, as in Go or Clojure, without   having to turn to shared memory or locks.
+* Crystal libraries are packed as Shards, and distributed via Git without needing a centralised repository.
+
+  Built in commands allow dependencies to be easily specified through a YAML file and fetched from their respective repositories.
+* ```text
+  Crystal 1.3.0 (2022-01-06)
+
+  LLVM: 13.0.0
+  Default target: x86_64-unknown-linux-gnu
+  ```

--- a/_style_guide/typography-rule.md
+++ b/_style_guide/typography-rule.md
@@ -1,0 +1,10 @@
+---
+title: Horizontal Rule
+type: typography
+---
+
+First paragraph.
+
+---
+
+Second paragraph.

--- a/_style_guide/typography-table.md
+++ b/_style_guide/typography-table.md
@@ -1,0 +1,11 @@
+---
+title: Table
+type: typography
+---
+
+| Operator | Description | Example | Overloadable | Associativity |
+|---|---|---|---|---|
+| `+`  | positive | `+1` | [yes](/) | right |
+| `&+` | wrapping positive | `&+1` | yes | right |
+| `-`  | negative | `-1` | yes | right |
+| `&-` | wrapping negative | `&-1` | yes | right |

--- a/_style_guide/typography-table_bordered.md
+++ b/_style_guide/typography-table_bordered.md
@@ -1,0 +1,27 @@
+---
+title: Bordered Table
+type: typography
+---
+
+<table class="bordered">
+  <thead>
+    <tr>
+      <th>Version</th>
+      <th>Date</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1.3.2</td>
+      <td>2022-01-18</td>
+    </tr>
+    <tr>
+      <td>1.3.1</td>
+      <td>2022-01-13</td>
+    </tr>
+    <tr>
+      <td>1.3.0</td>
+      <td>2022-01-06</td>
+    </tr>
+  </tbody>
+</table>

--- a/style-guide.md
+++ b/style-guide.md
@@ -1,0 +1,19 @@
+---
+title: Living Style Guide
+layout: page
+---
+
+<div class="container">
+A handy collection of all the colors, typography, UI patterns, and components of this website.
+
+Where applicable links to a component's Sass partial and/or Jekyll include are provided, along with short descriptions of typical usage.
+</div>
+
+{% assign componentsByType = site.style_guide | group_by: "type" %}
+
+{% for type in componentsByType %}
+<h2 id="{{ type.name }}" class="cf">{{ type.name | capitalize }}</h2>
+{% for component in type.items %}
+{% include style-guide/component.html %}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This adds a new page at `/style-guide` which contains examples of many common design components on this website. It serves as a living style guide to help ensure consistency of this site's style. It's easier to monitor relevant changes on a single page than having to browse several pages in order to find instances of less common design components.