### PR TITLE
Add feed for releases

### DIFF
--- a/releases/feed.xml
+++ b/releases/feed.xml
@@ -3,16 +3,17 @@ layout: none
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
-  <title>{{ site.name | xml_escape }}</title>
+  <title>Crystal Releases</title>
   {%- if site.description %}
   <subtitle>{{ site.description | xml_escape }}</subtitle>
   {%- endif %}
   <link href="{{ '/' | absolute_url }}" rel="alternate" type="text/html" />
   <link href="{{ page.url | absolute_url }}" rel="self" type="application/atom+xml" />
-  <link href="{{ '/releases/feed.xml' | absolute_url }}" rel="related" type="application/atom+xml" />
+  <link href="{{ '/feed.xml' | absolute_url }}" rel="related" type="application/atom+xml" />
   <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>{{ page.url | absolute_url | xml_escape }}</id>
-  {%- for post in site.posts limit:10 %}
+  {%- assign releases = site.releases | reverse -%}
+  {% for post in releases limit:10 %}
     <entry>
       <title>{{ post.title | xml_escape }}</title>
       {%- assign authors = post.author | split: ',' -%}
@@ -26,8 +27,8 @@ layout: none
       <published>{{ post.date | date_to_xmlschema }}</published>
       <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
       <id>{{ post.id | absolute_url | xml_escape }}</id>
-      {%- if post.excerpt and post.excerpt != empty %}
-      <summary type="html">{{ post.excerpt | strip_html | normalize_whitespace | xml_escape }}</summary>
+      {%- if post.summary and post.summary != empty %}
+      <summary type="html">{{ post.summary | strip_html | normalize_whitespace | xml_escape }}</summary>
       {%- endif %}
       <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}">{{ post.content | strip | xml_escape }}</content>
     </entry>


### PR DESCRIPTION
The current news feed at `/feed.xml` only contains blog posts. This adds a new feed at `/releases/feed.xml` which makes it easy to subscribe to releases.

Both feeds are not actually advertised on the website, so we'll need to add that, too.