### PR TITLE
Fix `/style-guide` permalink

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -1,6 +1,7 @@
 ---
 title: Living Style Guide
 layout: page
+permalink: /style-guide/
 ---
 
 <div class="container">


### PR DESCRIPTION
Without this override, the path is https://crystal-lang.org/style-guide.html, but it's supposed to be https://crystal-lang.org/style-guide/