### PR TITLE
Add `raw_content` plugin for style-guide source

### DIFF
--- a/_includes/blog_row.html
+++ b/_includes/blog_row.html
@@ -1,21 +1,20 @@
 <div class="row blog-post">
   <div class="col s12">
-      {% assign authors = include.post.author | split: ',' %}
-      {% for author in authors %}
+      {%- assign authors = include.post.author | split: ',' -%}
+      {%- for author in authors -%}
         <div class="author small">
           <img src="/assets/authors/{{ author }}.jpg" />
           <span class="author_name">{{ site.data.blog_authors[author].name }}</span>
-          {% if author == authors.last %}
+          {%- if author == authors.last %}
             <span class="date">{{ include.post.date | date_to_string }}</span>
-          {% endif %}
+          {% endif -%}
         </div>
-      {% endfor %}
+      {%- endfor -%}
 
     <a href="{{ include.post.url }}">
       <h3 class="title">{{ include.post.title }}</h3>
       <p class="summary">{{ include.post.summary }}</p>
     </a>
-
     <p>
       <i class="material-icons">chat_bubble_outline</i>
       <span class="disqus-comment-count" data-disqus-identifier="{{include.post.id}}"></span>

--- a/_includes/style-guide/component.html
+++ b/_includes/style-guide/component.html
@@ -12,7 +12,14 @@
   <div class="styleguide__code">
 
 {% highlight markdown %}
-{% include_relative {{ component.path }} %}
+{%- comment %}
+When this component is built from an include, show the result instead of the `include` directive.
+{% endcomment -%}
+{%- if component.module -%}
+{{ component.content }}
+{%- else -%}
+{{ component.raw_content }}
+{%- endif -%}
 {% endhighlight %}
 
   </div>

--- a/_plugins/raw_content.rb
+++ b/_plugins/raw_content.rb
@@ -1,0 +1,11 @@
+module Jekyll
+  class RawContent < Generator
+    def generate(site)
+      site.collections.each do |_, collection|
+        collection.docs.each do |post|
+          post.data['raw_content'] = post.content
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This picks up the idea from https://github.com/crystal-lang/crystal-website/pull/256#issuecomment-1024324438 to improve displayed source for style guide components.

Follow-up on #256