### PR TITLE
Fix team img preserve aspect ratio

### DIFF
--- a/_sass/pages/_team.scss
+++ b/_sass/pages/_team.scss
@@ -9,6 +9,7 @@
     grid-row-end: 5;
     width: 150px;
     height: 150px;
+    object-fit: cover;
     margin-right: 20px;
 
     .core-team-alumni > & {


### PR DESCRIPTION
If the image is not entirely square, `object-fit: cover` makes sure to preserve the aspect ratio, cropping the sides instead of distorting the image.