### PR TITLE
Fix top space and no bottom space

### DIFF
--- a/_sass/_site.scss
+++ b/_sass/_site.scss
@@ -160,6 +160,7 @@ hr.squares {
   }
   footer {
     text-align: center !important;
+    height: 100px !important;
     .right-align {
       text-align: inherit;
     }

--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -84,7 +84,7 @@
   #delaunay {
     @extend .black;
     position: absolute;
-    top: -94px;
+    top: -96px;
     right: 0;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
# In this PR
## Pixel Hunt
I think playing LucasArts old adventure games granted me a pixel-hunt kind of power 🕹🤓 and I found `2px` white space at the top of the site. Here they are in Chrome:
<img width="459" alt="Screen Shot 2022-02-17 at 19 15 06" src="https://user-images.githubusercontent.com/1175827/154761329-468c47ca-8ff2-4a95-badd-9fb8593da685.png">
and in Firefox:
<img width="341" alt="Screen Shot 2022-02-18 at 17 59 30" src="https://user-images.githubusercontent.com/1175827/154761448-92b66943-e337-49e8-bbc1-a505ce2cd62a.png">

It was a very tricky solution: replaced `top: -94px;` with `top: -96px;` 

And now in Chrome:
<img width="447" alt="Screen Shot 2022-02-17 at 19 15 24" src="https://user-images.githubusercontent.com/1175827/154761824-d2eab861-2c57-4320-9112-3852b3a5dad8.png">

and in Firefox:
<img width="701" alt="Screen Shot 2022-02-18 at 18 13 04" src="https://user-images.githubusercontent.com/1175827/154761910-84da74e0-cec8-47b1-8b56-f06b61d9438e.png">

A work of art! 👨‍🎨🎨

## More air
The next fix is only for Chrome (and not Firefox) 
The Problem? When resizing the browser window to the size where the 🍔 menu is shown, we can see that the `footer` changes its layout. This new footer's layout in Chrome does not have any space at the bottom.

Here is the layout using a wide view:
<img width="1239" alt="Screen Shot 2022-02-18 at 18 21 12" src="https://user-images.githubusercontent.com/1175827/154762883-0426b938-b151-4dab-8e88-0c2a3bfa719e.png">

But then, when resizing the browser (or visiting the site in your phone)
In Chrome
<img width="601" alt="Screen Shot 2022-02-17 at 19 27 35" src="https://user-images.githubusercontent.com/1175827/154763189-a2d619d2-5193-4f0b-886a-8b7fe1a7638b.png">
In Firefox
<img width="768" alt="Screen Shot 2022-02-18 at 18 25 26" src="https://user-images.githubusercontent.com/1175827/154763354-5e87da76-9514-4dc6-bcbc-cb3d083ccd0b.png">

**After the fix**, now we have more air in Chrome:
Chrome
<img width="642" alt="Screen Shot 2022-02-18 at 18 32 38" src="https://user-images.githubusercontent.com/1175827/154764160-53f186ff-9881-4214-bbe2-944b5e147ee1.png">
Firefox
<img width="724" alt="Screen Shot 2022-02-18 at 18 43 44" src="https://user-images.githubusercontent.com/1175827/154765293-9b20f8f6-1e94-4264-b353-8f0878ba4400.png">

And that's all for this PR!
