### PR TITLE
Remove Conference from menu. Add Conference section in Community page

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -9,8 +9,6 @@ main:
   url: /sponsors/
 - label: Community
   url: /community/
-- label: Conference
-  url: /conference/
 - label: Team
   url: /team/
 - label: Docs

--- a/community/index.html
+++ b/community/index.html
@@ -5,6 +5,16 @@ description: There are so many ways to get involved in Crystal. Here's a list of
 <div class="container">
 
 {% include community_row.html
+          title="Crystal 1.0 Conference"
+          divId="conference"
+          content="The Crystal 1.0 conference from 2021 with the recordings of all the talks!"
+          link_text="Crystal 1.0 conference"
+          url="/conference"
+          icon="chat_bubble_outline"
+          internal_link="true"
+%}
+
+{% include community_row.html
           title="Security Issues"
           divId="security"
           content="Should you find any security-related issue, please <strong>do not share them openly</strong> in the issue tracker. We have a dedicated mailbox where we keep track of them.<br /><br />


### PR DESCRIPTION
Related #282 

This is only a PoC and further improvement is needed before the PR is ready. For example, we need to:
- Add a good description to the `Conference` section.
- Change the icon (right now we are using the `forum` icon)