### PR TITLE
Fix: Remove whitespace in `<li>` whith block elements

### DIFF
--- a/_sass/pages/_blog.scss
+++ b/_sass/pages/_blog.scss
@@ -67,6 +67,7 @@
       padding-left: 2.5em;
     }
     li:before {
+      position: absolute;
       display: inline-block;
       content: counter(item) ".";
       counter-increment: item;
@@ -84,6 +85,7 @@
       padding-left: 2.5em;
     }
     li:before {
+      position: absolute;
       display: inline-block;
       content: "▪";
       width: 1.5em;


### PR DESCRIPTION
When list items contain a block element, that element is offset from the top of the list item by the height of the item indicator. 
| before | after|
|-|-|
| ![grafik](https://user-images.githubusercontent.com/466378/161995995-f65da67e-c476-44a3-9f57-ee785a770662.png) | ![grafik](https://user-images.githubusercontent.com/466378/161997077-84c03369-657b-4095-99e1-c262eed3e514.png) |
| ![grafik](https://user-images.githubusercontent.com/466378/161996101-9f6c4c5b-bca7-4c85-862a-ac2682b10e35.png) | ![grafik](https://user-images.githubusercontent.com/466378/161997159-a234d3c6-7324-4d3b-b690-c7e093d9ee8f.png) |

