### PR TITLE
Fix parsing of error message in 1.5.0 release post

### DIFF
--- a/_releases/2022-07-06-1.5.0-released.md
+++ b/_releases/2022-07-06-1.5.0-released.md
@@ -47,7 +47,7 @@ end
 
 Starting from 1.5.0 ([#11915](https://github.com/crystal-lang/crystal/pull/11915)) the example above will raise a warning:
 
-```
+```plaintext
  6 | def foo(name : Int32) : Nil
              ^---
 Warning: positional parameter 'name' corresponds to parameter 'number' of the overridden method FooAbstract#foo(number : Int32), which has a different name and may affect named argument passing


### PR DESCRIPTION
The syntax-highlighter only shows the last character in a single-quoted token of a Crystal code block (asuming it's a Crystal Char), but here it's an error message - so the rule shouldn't apply.
<img width="928" alt="Codeblock showing variables with incomplete names like 'e' instead of 'name'" src="https://user-images.githubusercontent.com/5470539/178020053-28686632-4522-4be1-8304-7d4415af8aef.png">

With the fix:

<img width="921" alt="Same block, without colors, but showing the full variable 'name'" src="https://user-images.githubusercontent.com/5470539/178020162-6b6d708d-3eb8-4e08-9a07-fa5f345a5ba7.png">


Reported by @beta-ziliani

Co-authored-by: Johannes Müller <straightshoota@gmail.com>