### PR TITLE
Adding rel="sponsored nofollow" to sponsors' links

### DIFF
--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -29,7 +29,7 @@ layout: base
                 {% if sp.logo %}
                   <div class="logo">
                     {% if sp.url %}
-                      <a href="{{sp.url}}" target="_blank" rel="sponsored">
+                      <a href="{{sp.url}}" target="_blank" rel="sponsored nofollow">
                         <img src="/assets/{{ sp.logo }}" />
                       </a>
                     {% else %}
@@ -41,11 +41,7 @@ layout: base
                 {% endif %}
               </td>
               <td class="name">
-                {% if sp.url and sp.logo %}
-                  <a href="{{sp.url}}" target="_blank" rel="sponsored">
-                    {{sp.name}}
-                  </a>
-                {% elsif sp.url %}
+                {% if sp.url %}
                   <a href="{{sp.url}}" target="_blank" rel="sponsored nofollow">
                     {{sp.name}}
                   </a>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -29,7 +29,7 @@ layout: base
                 {% if sp.logo %}
                   <div class="logo">
                     {% if sp.url %}
-                      <a href="{{sp.url}}" target="_blank">
+                      <a href="{{sp.url}}" target="_blank" rel="sponsored">
                         <img src="/assets/{{ sp.logo }}" />
                       </a>
                     {% else %}
@@ -41,8 +41,12 @@ layout: base
                 {% endif %}
               </td>
               <td class="name">
-                {% if sp.url %}
-                  <a href="{{sp.url}}" target="_blank">
+                {% if sp.url and sp.logo %}
+                  <a href="{{sp.url}}" target="_blank" rel="sponsored">
+                    {{sp.name}}
+                  </a>
+                {% elsif sp.url %}
+                  <a href="{{sp.url}}" target="_blank" rel="sponsored nofollow">
                     {{sp.name}}
                   </a>
                 {% else %}


### PR DESCRIPTION
In order to prevent lowering the rank of the site, we mark each sponsor link with `rel="sponsored"`, also adding `nofollow` to those that do not meet a certain criteria. Currently, the criteria is having an icon, that corresponds to the >=75usd tier.