### PR TITLE
Change the width of flag classes for a better pretty main page

### DIFF
--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -222,7 +222,7 @@
 
 .flag {
   margin: auto;
-  width: min-content;
+  width: max-content;
   background-color: $white;
   line-height: 30px;
   border-radius: 35px;


### PR DESCRIPTION
Hi team! 
I found content that goes over div on crystal web page. Personally, `width: max-content` looks better than `width: min-content` in the `flag` class, so check it out!

![](https://user-images.githubusercontent.com/13212227/191962122-53e6617d-a110-46af-b43d-0dbb4f832484.png)

## Diff
|        | Old | New |
|--------|-----|-----|
| PC     |  ![](https://user-images.githubusercontent.com/13212227/191962065-7f789199-dadb-41eb-97f7-c0e16b4262a2.png)   |   ![](https://user-images.githubusercontent.com/13212227/191962054-632a0673-9668-4391-a39f-bedfbe8c6492.png)  |
| Mobile |  ![](https://user-images.githubusercontent.com/13212227/191962070-4fd5f26f-a450-4cbc-be7e-1591490bad0b.png)   |   ![](https://user-images.githubusercontent.com/13212227/191962072-c665d791-8392-4917-a736-2cc9bcb4516f.png)  |

Cheers.

---- 
Signed-off-by: hahwul <hahwul@gmail.com>