### PR TITLE
Fix team/index.html typo

### DIFF
--- a/team/index.html
+++ b/team/index.html
@@ -10,7 +10,7 @@ description: >
     <p>
       This page introduces some of the most notable members, especially the
       Core Team, and the Steering Council. Their roles are defined by the
-      <a href="/community/governance">Crystal Governance document</a>.
+      <a href="/community/governance.html">Crystal Governance document</a>.
     </p>
   </section>
 


### PR DESCRIPTION
The URL in the link to the governance docs is missing “.html” leading to a bad link.