### PR TITLE
Fix example in release notes for 1.2.0

### DIFF
--- a/_releases/2021-10-14-1.2.0-released.md
+++ b/_releases/2021-10-14-1.2.0-released.md
@@ -27,12 +27,11 @@ We discovered that two bugs appearing on [Windows](https://github.com/crystal-la
 It is now possible to assign a subclass of a generic class to an element of [the parent class](https://github.com/crystal-lang/crystal/pull/11250):
 
 ```crystal
-class Foo(T); end
+class A; end
+class B(T) < A; end
 
-class Bar(T) < Foo(T); end
-
-x = Foo
-x = Bar
+x = A
+x = B(String)
 ```
 
 Also pertain to generic classes, there were situations in which the compiler was not properly substituting the generic argument ([#11166](https://github.com/crystal-lang/crystal/pull/11166), [#11067](https://github.com/crystal-lang/crystal/pull/11067).


### PR DESCRIPTION
The original example as used in the PR https://github.com/crystal-lang/crystal/pull/11250 but it was stated that this does not work yet with that change.

Fixes #332