### PR TITLE
Fix main feed to include release notes as well as blog posts

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -12,7 +12,8 @@ layout: none
   <link href="{{ '/releases/feed.xml' | absolute_url }}" rel="related" type="application/atom+xml" />
   <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>{{ page.url | absolute_url | xml_escape }}</id>
-  {%- for post in site.posts limit:10 %}
+  {%- assign documents = site.releases | concat: site.posts | sort: 'date' | reverse -%}
+  {%- for post in documents limit:10 %}
     <entry>
       <title>{{ post.title | xml_escape }}</title>
       {%- assign authors = post.author | split: ',' -%}


### PR DESCRIPTION
Since #214 release notes are a separate collection which means they no longer show up in the posts collection. Thus they also didn't show up in the main feed (https://crystal-lang.org/feed.xml).

This patch combines release notes and blog posts in that feed.

There is still the release-only feed at https://crystal-lang.org/releases/feed.xml