### PR TITLE
Normalize header levels in markdown posts

### DIFF
--- a/_posts/2013-09-04-happy-birthday-crystal.md
+++ b/_posts/2013-09-04-happy-birthday-crystal.md
@@ -15,7 +15,7 @@ is growing bigger.
 
 Here's a summary of what we have in the language right now.
 
-### Efficient code generation
+## Efficient code generation
 
 Crystal is **not** interpreted. It doesn't have a virtual machine. The code is compiled to
 native machine code by using LLVM.
@@ -24,7 +24,7 @@ You don't specify the types of variables, instance variables or method arguments
 like is usually done in statically compiled languages. Instead, Crystal tries to be as
 smart as possible and infers the types for you.
 
-### Primitive types
+## Primitive types
 
 Primitive types map to native machine types.
 
@@ -37,7 +37,7 @@ true    # Bool
 'a'     # Char
 ```
 
-### ASCII Strings
+## ASCII Strings
 
 They come in many flavors, like in Ruby, and they also support interpolation.
 
@@ -53,7 +53,7 @@ Did you know that [String](https://github.com/crystal-lang/crystal/blob/master/s
 is implemented in Crystal itself? There's just very small magic to make it have the
 size and pointer to the chars buffers, but everything else is built on top of that.
 
-### Symbols
+## Symbols
 
 ```ruby
 :foo
@@ -62,7 +62,7 @@ size and pointer to the chars buffers, but everything else is built on top of th
 At runtime, each symbol is represented by a unique integer. A table of integer to string is built for
 implementing Symbol#to_s (but there's no way right now to do String#intern).
 
-### Union types
+## Union types
 
 You don't need to specify the type of a variable. If it is assigned multiple types,
 it will have those types at compile-time. At run-time it will have only one.
@@ -96,7 +96,7 @@ if a.responds_to?(:succ)
 end
 ```
 
-### Methods
+## Methods
 
 In Crystal methods can be overloaded. The overloads come from the number of arguments,
 type restrictions and *yieldness* of a method.
@@ -135,7 +135,7 @@ it's a compile time error.
 The last bit, overloading based on whether a method yields or not, will probably change
 and needs to be re-thought.
 
-### Classes
+## Classes
 
 No need to specify the types of instance variables, but all types assigned to
 an instance variable will make that variable have a union type.
@@ -208,17 +208,17 @@ Maybe it doesn't have an efficient solution. At least we didn't find anyone who 
 able to do it. Generic types are a small sacrifice, but in return we get much
 faster compile times.
 
-### Modules
+## Modules
 
 Of course, modules are also present in Crystal, and they can also be generic.
 
-### Blocks
+## Blocks
 
 For now, blocks can't be saved to a variable or passed to another method. That means,
 we still lack closures. It's not an easy thing to do if we want a smart type inference,
 so we need some time to think it over.
 
-### Bindings to C
+## Bindings to C
 
 You can declare bindings to C in Crystal, no need to use C, make wrappers or
 use another language. For example, this is part of the SDL binding:
@@ -244,7 +244,7 @@ end
 value = LibSDL.init(LibSDL.INIT_TIMER)
 ```
 
-### Pointers
+## Pointers
 
 You can allocate memory and interface with C by having Pointers as a type in the language.
 
@@ -252,7 +252,7 @@ You can allocate memory and interface with C by having Pointers as a type in the
 values = Pointer(Int32).malloc(10) # Ask for 10 ints
 ```
 
-### Regular expressions
+## Regular expressions
 
 Regular expressions are implemented, for now, with C bindings to the PCRE library. Again,
 [Regexp](https://github.com/crystal-lang/crystal/blob/fd6c0238f6e7725d307d4c010d8c860e38a46d72/src/regexp.cr) is entirely written in Crystal.
@@ -263,16 +263,16 @@ $1                           #=> "foo"
 $2                           #=> "baz
 ```
 
-### Ranges
+## Ranges
 
 Once again, [implemented in Crystal](https://github.com/crystal-lang/crystal/blob/master/src/range.cr).
 
-### Exceptions
+## Exceptions
 
 You can raise and rescue exceptions. They are implemented using libunwind. We are still lacking line
 numbers and filenames in the stacktraces.
 
-### Exporting C functions
+## Exporting C functions
 
 You can declare functions to be exported to C, so you can compile Crystal code and use it in C
 (although there's still no compiler flag to generate an object file, but it should be easy to implement).
@@ -283,7 +283,7 @@ fun my_c_function(x : Int32) : Int32
 end
 ```
 
-### Macros
+## Macros
 
 This is an experimental feature of the language where you can generate source code
 from AST nodes.
@@ -306,7 +306,7 @@ The macros getter, setter and property are implemented in a similar way, but we'
 been thinking of a more powerful and simpler way to achieve the same thing so this
 feature might disappear.
 
-### Yield with scope
+## Yield with scope
 
 Similar to yield, but changes the implicit scope of the block.
 
@@ -329,7 +329,7 @@ are involved.
 Something similar can be achieved in Ruby with instance_eval(&block), but for now
 we find it easier to implement it this way, and maybe easier to use.
 
-### Specs
+## Specs
 
 We'be built a [very small clone of RSpec](https://github.com/crystal-lang/crystal/blob/master/src/spec.cr) and we are using it to test the standard
 library as well as the new compiler. Here's a sample spec for the Array class:

--- a/_posts/2013-09-15-to-proc.md
+++ b/_posts/2013-09-15-to-proc.md
@@ -5,7 +5,7 @@ summary: Shortcut syntax for writing one-argument blocks
 author: asterite
 ---
 
-### Ruby to_proc
+## Ruby to_proc
 
 Ruby blocks are powerful. You can easily convert an array of numbers to strings:
 
@@ -41,7 +41,7 @@ Finally, Ruby's implementation of [Symbol#to_proc](http://ruby-doc.org/core-2.0.
 has a cache of Procs so they are not created every time you use the same symbol, but still, it's slightly
 slower than a normal block.
 
-### Crystal to_proc?
+## Crystal to_proc?
 
 At first we thought about making Crystal have the same syntax for this, but a bit hacky: if you
 do `&:to_s`, because the argument to `&` is a Symbol we can rewrite the source code to receive a block:

--- a/_posts/2015-09-05-tools.md
+++ b/_posts/2015-09-05-tools.md
@@ -9,7 +9,7 @@ Crystal compiler does a lot of work in order to allow the programmer be more exp
 
 Since 0.7.7 the compiler comes with some initials tools that will help the programmer know what the compiler is understanding from the code and to navigate through in a more interesting way.
 
-# Go to implementations tool
+## Go to implementations tool
 
 When compiling a method call, the compiler knows exactly which method definition will be called. But, when the programmer is viewing the source code, there was no way (other than string search) to reach the method definition.
 
@@ -37,7 +37,7 @@ You can pass `--format json` to make a computer friendly output and build someth
 
 If you use [Atom](https://atom.io) download them and just press `⌘⌥i` / `ctrl-alt-i` while your cursor is over the `add` in line 5.
 
-## Multiple implementations
+### Multiple implementations
 
 This tools does not only will be allow you avoid `def foo` vs `def self.foo` string matching hell, but will point which are the real candidates of a method call.
 

--- a/_posts/2016-05-26-heroku-buildpack.md
+++ b/_posts/2016-05-26-heroku-buildpack.md
@@ -12,7 +12,7 @@ However, due to some flaws in the approach, the buildpack failed to stay up to d
 
 While efforts to develop web frameworks continue nowadays, we wanted to share the very basic steps to use the Crystal buildpack to deploy a web application in Heroku without the need for any additional dependencies.
 
-# Create a Crystal project
+## Create a Crystal project
 
 This assumes you already have [crystal installed](http://crystal-lang.org/docs/installation/).
 
@@ -74,7 +74,7 @@ Open your browser at [http://0.0.0.0:8080](http://0.0.0.0:8080).
 
 To stop the server just terminate the process by pressing `Ctrl+C`.
 
-# Herokufy it
+## Herokufy it
 
 Right now the project knows nothing about Heroku. To get started, a Heroku application needs first to be registered. The easiest way to do this is via the [Heroku toolbelt](https://toolbelt.heroku.com/):
 
@@ -143,7 +143,7 @@ Listening on http://0.0.0.0:9090
 ^C
 </pre>
 
-# Deploy!
+## Deploy!
 
 When you are ready to go live with your app just deploy it the usual way with `git push heroku master`.
 
@@ -223,5 +223,3 @@ Find all the sample source code used at
 [https://github.com/bcardiff/sample-crystal-heroku101](https://github.com/bcardiff/sample-crystal-heroku101).
 
 To contribute to crystal buildpack, just [fork it](https://github.com/crystal-lang/heroku-buildpack-crystal). Contributions are welcome!
-
-

--- a/_posts/2016-12-29-crystal-new-year-resolutions-for-2017-1-0.md
+++ b/_posts/2016-12-29-crystal-new-year-resolutions-for-2017-1-0.md
@@ -13,11 +13,11 @@ The major issue is clear: **stability**. While Crystal is a beautiful language t
 
 As such, and in line with our goal of seeing the language grow, we are setting a **new year resolution to have Crystal reach the 1.0 milestone in 2017**.
 
-# What 1.0 means
+## What 1.0 means
 
 Alpha, beta, and stable (i.e. 1.0) might mean different things for different people, even within the very Crystal team. The fundamental idea behind achieving a 1.0 milestone is to **reach a point where breaking changes to the core of the language are down to a minimum**. There can (and will, believe me) be more additions and features to the language afterwards, of course, or even modifications to tools or the standard library, but we want to assure that migrating to a subsequent version of the language should be an easy task.
 
-# The road towards a 1.0 release
+## The road towards a 1.0 release
 
 To reach 1.0 we need to work on those key features that could require breaking changes to the language; and we have identified the following:
 
@@ -28,7 +28,7 @@ To reach 1.0 we need to work on those key features that could require breaking c
 - **Macros**: Crystal’s response to dynamic languages metaprogramming feature are [compile-time macros](https://crystal-lang.org/reference/syntax_and_semantics/macros.html), which provide a way to solve most of the same problems. Macros can manipulate an AST to output new code, call external programs, have access to the type system, or even hook into the compilation process. As such, part of the work before 1.0 will be to review them, and make sure they play along well with the rest of the language, as we don’t want to have any breaking changes to the macro language after 1.0.
 - **Syntax**: Similar to the point above, once 1.0 is released, any changes to the language’s syntax will be frozen. Though Crystal has inherited most of Ruby’s syntax, some Crystal-specific items need a syntax of their own. Sincerely, we don’t anticipate any big changes here, but it would be irresponsible to freeze it without a proper review.
 
-# How to get there
+## How to get there
 
 Considering we still plan on working on the standard library in parallel, as well as in fixing any bugs that come along the way, achieving all of the items above within a year is no easy feat.
 
@@ -38,7 +38,7 @@ And second, but not less important, we plan on **leveraging all the power of the
 
 After that, from the community perspective, we plan to work on **lowering the barrier for newcomers to the language**. We want to make sure it’s clear what Crystal is and what it is not, especially with so many people coming directly from a dynamic languages background. We will focus not just in documentation but in tutorials as well, and assist in defining use cases for Crystal that could in turn shape the language itself.
 
-# Next steps
+## Next steps
 
 As excited as we are about all the things to come to Crystal during 2017, we don’t want to lose track of the **immediate next steps**. We will be working heavily on parallelism first, and on leveraging any existing efforts towards Windows support. From the community standpoint, we will be reviewing the contribution guidelines and rethink the GitHub issues labels, then re-tag issues as appropriate; we want to have issues ready for newcomers to contribute, as well as for more experienced members of the community to tackle.
 

--- a/_posts/2017-01-06-the-charly-programming-language.md
+++ b/_posts/2017-01-06-the-charly-programming-language.md
@@ -9,11 +9,11 @@ author: lschutz
 
 *Today’s guest author is Leonard Schütz. He created the Charly programming language as a means to learn how to create a programming language, and after a first iteration in Ruby, he moved to Crystal to implement the language interpreter. In this post, he presents the language, shows how it works, and why he chose Crystal to implement it.*
 
-# Introduction
+## Introduction
 
 Charly is a dynamically typed and object-oriented programming language. The syntax is mostly inspired by languages like JavaScript or Ruby, but offers more freedom when writing. The first difference one might notice is the absence of semicolons or the missing need for parenthesis in most of the languages control structures. Charly, as it is right now, is just a toy language written in spare time.
 
-# How does it look?
+## How does it look?
 
 Below is an implementation of the [Bubblesort algorithm](https://en.wikipedia.org/wiki/Bubblesort) written in Charly. It is part of the standard library which is also written in Charly.
 
@@ -76,7 +76,7 @@ This program prints out the [Mandelbrot set](https://en.wikipedia.org/wiki/Mande
 
 [This link](https://gist.github.com/KCreate/62f0f135697ad3df3b3801b194b03acc) takes you to an expression parser / interpreter written entirely in Charly. It supports the addition and multiplication of integer values.
 
-# How does it work?
+## How does it work?
 
 First, Charly turns the source file into a list of tokens. A token is basically just a string with a type.
 A simple hello-world program may consist of the following tokens:
@@ -114,7 +114,7 @@ Depending on which value is on which side, this procedure might produce completl
 
 A `IdentifierLiteral` would load a value from the current scope, a `CallExpression` would invoke a pre-defined function and so on.
 
-# Why Crystal?
+## Why Crystal?
 
 The main reasons behind using Crystal for this project were speed and simplicity.
 
@@ -130,7 +130,7 @@ It took me about a week to rewrite most of the interpreter in Crystal, with only
 
 Another great thing about developing in Crystal, is that the compiler itself is also written in Crystal. This means Crystal is self-hosted. There were multiple occasions where I copied code from Crystal's compiler and adapted it for my own use. Crystal’s parser and lexer for example were really helpful in understanding how these things work (I had never written a parser and lexer before).
 
-# The Macro System
+## The Macro System
 
 The Macro system was really handy in a lot places. It was mainly used to avoid boilerplate and to follow the DRY pattern.
 
@@ -141,13 +141,13 @@ For some real examples of how the Macro system could be used, look at these file
 
 Crystal's standard library for example, uses macros to provide the [property](https://crystal-lang.org/api/master/Class.html#property%28%2Anames%29-macro) method. You can use it to avoid boilerplate when introducing new instance variables to your classes.
 
-# Conclusion
+## Conclusion
 
 In it’s current state, Charly is just a learning project for myself. At the moment, I wouldn’t recommend using it for anything serious beside as a learning resource on how to write an interpreter yourself. Charly is being developed on [GitHub](https://github.com/charly-lang), so feel free to open any issues, propose new features or even send your own pull requests. Feedback in the comments of this article is also greatly appreciated.
 
 I’ve started using Crystal around August 2016 and I’m absolutely in love with it. It is one of the most expressive and rewarding languages I have ever written code in. If you haven’t used Crystal before, you should try it out now.
 
-# About the Author
+## About the Author
 
 My name is Leonard Schütz, I'm a 16 year old student from Switzerland.
 I'm currently an apprentice at Siemens in the field of Healthcare, where I work mostly with PHP, EWS and other web technologies.
@@ -157,7 +157,7 @@ Feel free to follow me on [Twitter](https://twitter.com/leni4838), [GitHub](http
 
 Thanks for reading!
 
-# Links & Sources
+## Links & Sources
 
 * Leonard Schütz: [leonardschuetz.ch](https://leonardschuetz.ch)
 * Charly Programming Language: [charly-lang/charly](https://github.com/charly-lang/charly)

--- a/_posts/2017-09-25-neuralegion-and-crystal.md
+++ b/_posts/2017-09-25-neuralegion-and-crystal.md
@@ -8,12 +8,12 @@ author: neuralegion
 At [NeuraLegion](http://neuralegion.com), we have been using Crystal for quite some time now.
 We would like to share our experience in this brief article, starting from how we discovered Crystal, fell in love with it, and why we decided to make Crystal our language of choice.
 
-# About Us
+## About Us
 Before we begin our story about Crystal, let us introduce ourselves. We are a new startup company with a passion to make the world a better place through machine learning and AI. We're currently focusing on the cyber security world, an increasingly crucial part of our daily lives.
 
 NexPloit, our first product (which will be released soon), will redefine software Penetration Testing through the power of AI.
 
-# Why Crystal?
+## Why Crystal?
 Grandiose statements aside, when we started working on our first product, we were already long time fans of Ruby. We love Ruby because it is object oriented by default, making it easy to use, it is versatile and has a good pool of libraries developed by the community. In addition, we find Ruby beautiful and well matured as a programming language.
 
 However, when we rolled up our sleeves and began to build NexPloit, there were some innate characteristics of Ruby which did not fulfill our specific needs. To name a few examples:
@@ -25,13 +25,13 @@ However, when we rolled up our sleeves and began to build NexPloit, there were s
 
 For the reasons we mentioned and some others, we needed a programming language which had all the advantages of Ruby, but without the disadvantages. That's when we discovered Crystal and almost immediately fell in love with it ❤️. Crystal's slick coding experience, ease of lower-level library bindings, type safety in compile-time without the need to even execute the program, and finally the lightning-fast runtime performance gave us what we needed to really set the keyboard on fire! We can honestly say that Crystal gave us the tools to elegantly and efficiently take NexPloit and make it from an idea into a reality.
 
-# How To Make Crystal Even Better
+## How To Make Crystal Even Better
 Now let's be fair - we love Crystal, however there is always some room for improvement. One of the challenges we faced with Crystal was the lack of shards (Crystal's "gems") for machine learning and scientific tools. However, expecting other people to add shards is unfair, so we decided to create a shard for [Crystal-FANN](https://github.com/NeuraLegion/crystal-fann) as the groundwork for our needs (and we made it available on our Github page for anyone who may need it). For now, Crystal-FANN seems to hit the spot for us, but we are still considering the addition of Torch or TensorFlow if we conclude that FANN by itself is not enough.
 
-# Summary
+## Summary
 Should you try Crystal? Absolutely! Crystal is an amazing language, it is really easy to work with and it produces great results. We definitely recommend Crystal, try it and you will enjoy it for sure!
 
-# Crystal Vs Ruby - Disclaimer
+## Crystal Vs Ruby - Disclaimer
 We want to point out that this article is solely our personal experience and opinion regarding why we decided to go with Crystal. We still love Ruby and would highly recommend it to anyone who may have other needs than us. Ruby is well established and has a great supporting community, which is especially useful for programming beginners. And we believe that Ruby has many more great things ahead.
 
 Here is a comparison between some of the parameters which were important to us:
@@ -47,7 +47,7 @@ Runs in virtual machine | Compiled native code
 
 
 
-# Useful Links
+## Useful Links
 [Our website](http://neuralegion.com)
 
 [FANN machine learning library](http://leenissen.dk/fann/wp/)

--- a/_posts/2017-10-27-diploid-and-crystal.md
+++ b/_posts/2017-10-27-diploid-and-crystal.md
@@ -10,11 +10,11 @@ description: "At Diploid, we have been using Crystal for quite some time now. We
 At [Diploid](http://www.diploid.com/), we have been using Crystal for quite some time now.
 We would like to share our experience in this interview, answering questions relevant to companies wanting to use Crystal for production.
 
-# About Us
+## About Us
 Diploid is a company based in Leuven, Belgium. We provides services and software to hospitals and labs for diagnosing
 rare diseases using clinical genome analysis.
 
-# What are the production projects that you use Crystal for?
+## What are the production projects that you use Crystal for?
 We are using Crystal for parts of Moon, the first software package to autonomously diagnose rare disease using artificial intelligence. Moon is being used by hospitals worldwide to diagnose patients with severe genetic conditions. The software requires the patient’s symptoms, as well as his/her genome data. It will then come up with the most likely mutation to explain the patient’s condition.
 
 Before Moon, geneticists had to manually filter and rank mutations using special software in order to reach a diagnosis. This process can take several hours up to several days. Moon does the filtering and ranking automatically and proposes a diagnosis within 3 minutes.
@@ -23,7 +23,7 @@ Moon has been written mostly in Ruby. We’ve chosen Ruby for several reasons: r
 
 <img src="/assets/blog/diploid-moon.png" class="center"/>
 
-# Why did you decide to use Crystal for these applications?
+## Why did you decide to use Crystal for these applications?
 When looking for a language that we could use to replace performance critical code in our Ruby codebase, we evaluated many options: Swift, Elixir, Go and Crystal. We specifically evaluated performance, syntax and ease-of-use. Performance was assessed using a small benchmark script that includes the performance critical
 operations that are typical for genome analysis (mostly string operations). Go topped the performance list, followed by Crystal. Surprisingly, Ruby outperformed Swift. Go clearly won the performance criterium. Performance is not everything, however: infrastructure is very cheap compared to developer time. While Go is an interesting
 language with a great concurrency model, it lacks in several other areas. Features that we take for granted in Ruby or other languages, are not available in Go. Examples include operator overloading or keyword extensibility, as well as true OOP. Moving from Ruby to Go sometimes feels like ignoring 20 years of progress made in language design.
@@ -31,7 +31,7 @@ language with a great concurrency model, it lacks in several other areas. Featur
 Crystal, as the second best performer, combines this still excellent performance with a very Ruby-like syntax. Given that the rest of our code base has been written in Ruby, it’s a great match. Moreover, Crystal has a Go-like concurrency model, so it basically takes the best from the Ruby world (expressive syntax, full OOP) and
 combines it with the best of Go (concurrency model, performance).
 
-# What kinds of problems does Crystal solve best?
+## What kinds of problems does Crystal solve best?
 Any problem that is currently being solved by Ruby, Python, Go or Rust could potentially be solved in Crystal.
 Given its similarity to Ruby, web frameworks will be an important part of the Crystal ecosystem. However, Crystal has a lot of potential in other fields too. Python is popular in data science, but it’s far from the fastest language. With Crystal, data scientists could have the ease-of-use of Python/Ruby combined with the performance
 of C. These advantages could make Crystal very suitable for domains like bioinformatics, where performance is really important.
@@ -40,25 +40,25 @@ As many people in the bioinformatics field don’t have a formal CS/engineering 
 easy to learn is important as well. Crystal does very well on both fronts.
 In addition, due to its expressive nature and low barrier to entry - traits it inherited from Ruby - Crystal is a great tool for general scripting and systems software.
 
-# How was your experience of developing with Crystal?
+## How was your experience of developing with Crystal?
 When coming from Ruby, working in Crystal feels like coming home. Syntactically, Crystal is highly similar: the only major difference is the static typing. While this takes a bit to get used to, the transition was really smooth and easy. Many lines of code can literally be copied from a Ruby project and pasted into a Crystal project and they will just work. Some lines do need additional type annotations, however.
 
 Apart from that, the only major difference is that the rubygems (Ruby libraries) ecosystem is very expansive. Crystal has its own version of gems, called shards. While the number of shards has grown exponentially in the past few months, it’s still way behind the rubygems ecosystem, or the Go ecosystem for that matter.
 
-# Are there any aspects of Crystal that specifically benefit customer satisfaction?
+## Are there any aspects of Crystal that specifically benefit customer satisfaction?
 The Crystal code we use in production was not ported from Ruby, it was written from scratch in Crystal. However, in order to test the difference in performance - and also out of pure curiosity - we ported the code from Crystal to Ruby. For this particular project, we noticed that the Crystal version was 4.4x - 6.1x faster.
 This made a big difference in user experience. It means that for smaller data sets, Moon can present results in near real time (about 540 ms), which feels instant to the user. The corresponding Ruby program takes 2.5 seconds for the same task. When analysing larger data sets, the difference was even bigger: on average 27 seconds for Crystal compared to 2 minutes and 50 seconds for almost exactly the same Ruby code, a more than 6x speedup! When analysing hundreds of samples, these time differences become even more important.
 
-# What advantages or disadvantages have you experienced from deploying a Crystal application in production?
+## What advantages or disadvantages have you experienced from deploying a Crystal application in production?
 As mentioned, the speed increase is really significant. In addition, the ability to create a binary is convenient, as it allows for easy deployment. Compiling a binary also allows us to easily share software with our internal users
 and testers. With Ruby, we need to setup rvm or rbenv, install the latest Ruby version, install rubygems and install all required gems. With Crystal, it’s as easy as copying one file.
 
-# What do you like the most about Crystal, compared to other languages?
+## What do you like the most about Crystal, compared to other languages?
 Performance, the ability to create real binaries and the Ruby-like syntax are the most important Crystal selling points for me. Another advantage is that Crystal makes it very easy to create bindings to a C
 library - no need to write C code.
 Last but not least, Crystal has an amazing community of friendly and skilled developers. It started with Ary, Juan and Brian at Manas, creating the language and helping the Crystal newbies. In the meantime, it seems like the entire community has copied their attitude of providing help and pointers to everyone who’s interested in this very promising language.
 
-# Useful links
+## Useful links
 [Diploid](http://www.diploid.com/)
 
 [Moon software](http://www.diploid.com/moon)

--- a/_posts/2017-11-03-2017-crystal-survey-2017-results.md
+++ b/_posts/2017-11-03-2017-crystal-survey-2017-results.md
@@ -19,7 +19,7 @@ Without further ado, let's take a look at the results.
 
 We wanted to learn how you discovered Crystal, and were surprised to find that a lot of you arrived at Crystal through search engines. On the other hand, we confirmed how important HackerNews and Reddit are to divulge young and small projects such as Crystal. Every now and then, someone from the community posts something interesting about Crystal, the post makes it to HN and Reddit front pages and in the next few days we notice a wave of new users and contributors on the different community channels.
 
-# Using Crystal
+### Using Crystal
 
 ![47.2% Yes, I'm using Crystal for hobby projects, 32.1% No, but I' planning to use Crystal, %10.7 No, I'm not using Crystal, %9.9 Yes, I'm Using Crystal in production](https://cdn.pbrd.co/images/GP33qmx.png
 "%47.2 Yes, I'm using Crystal for hobby projects, 32.1% No, but I'm planning to use Crystal, 10.7% No, I'm not using Crystal, 9.9% Yes, I'm Using Crystal in production")
@@ -84,7 +84,7 @@ Crystal developers do love using Vim, here's the major editors being used
 - Sublime Text - 28.4%
 - Emacs - 8.1%
 
-# Platforms
+### Platforms
 
 ![Linux 66%, Mac OS 57.5%, Windows 17.9%, 2.8% BSD-variant](https://cdn.pbrd.co/images/GPbEV09.png
   "Linux 66%, Mac OS 57.5%, Windows 17.9%, 2.8% BSD-variant")
@@ -97,7 +97,7 @@ Linux is the main platform Crystal developers choose followed by Mac OS. There's
 
 We see a similar pattern in target platforms. Linux is the most targeted platform. Interestingly we see Android, iOS and Javascript in a noticable ratio.
 
-# Towards 1.0
+### Towards 1.0
 
 ![0.23.* 56.9%, Not sure 22.4%, Master 6.4%](https://cdn.pbrd.co/images/GPbKSji.png
   "0.23.* 56.9%, Not sure 22.4%, Master 6.4%")
@@ -135,9 +135,9 @@ We asked what tools would make Crystal developers more productive.
 - Code coverage & Linters
 - Faster compile times
 
-# Learning Resources
+## Learning Resources
 
-## Which learning resources, if any, did you use to learn Crystal?
+### Which learning resources, if any, did you use to learn Crystal?
 
 - The official Crystal docs (https://crystal-lang.org/reference/)
 - Crystal for Rubyists (http://www.crystalforrubyists.com/)
@@ -210,7 +210,7 @@ Crystal developers come from various programming languages, most of them being d
 
 ---
 
-# Closing Thoughts
+## Closing Thoughts
 
 At the end of the survey, we asked: “Anything else you’d like to tell us?”
 

--- a/_posts/2017-11-03-2017-crystal-survey-2017-results.md
+++ b/_posts/2017-11-03-2017-crystal-survey-2017-results.md
@@ -19,7 +19,7 @@ Without further ado, let's take a look at the results.
 
 We wanted to learn how you discovered Crystal, and were surprised to find that a lot of you arrived at Crystal through search engines. On the other hand, we confirmed how important HackerNews and Reddit are to divulge young and small projects such as Crystal. Every now and then, someone from the community posts something interesting about Crystal, the post makes it to HN and Reddit front pages and in the next few days we notice a wave of new users and contributors on the different community channels.
 
-### Using Crystal
+## Using Crystal
 
 ![47.2% Yes, I'm using Crystal for hobby projects, 32.1% No, but I' planning to use Crystal, %10.7 No, I'm not using Crystal, %9.9 Yes, I'm Using Crystal in production](https://cdn.pbrd.co/images/GP33qmx.png
 "%47.2 Yes, I'm using Crystal for hobby projects, 32.1% No, but I'm planning to use Crystal, 10.7% No, I'm not using Crystal, 9.9% Yes, I'm Using Crystal in production")

--- a/_posts/2018-01-25-amber-crystalizing-rails-and-phoenix.md
+++ b/_posts/2018-01-25-amber-crystalizing-rails-and-phoenix.md
@@ -15,7 +15,7 @@ Here are a few reasons why I <3 Amber:
 - Open and welcoming framework development team
 - Raw Speed
 
-# Familiar Framework Design
+## Familiar Framework Design
 
 Amber projects follow similar design to Rails and other MVC focused web frameworks. It borrows organization and concepts where they’re successful and builds on that foundation where developer efficiency or simplicity can be improved.
 
@@ -42,7 +42,7 @@ Rails veterans will recognize many of these files and folders immediately:
 
 Models, views, controllers, and migrations are all right where you’d expect them. You’ll feel right at home. Environment config files follow a familiar style and a working asset pipeline is available right out of the box, if you want it (thanks to webpack).
 
-# Compile Time checks
+## Compile Time checks
 Thanks to Crystal, a large portion of an Amber project is evaluated at compile time. Never again get an email from production complaining about something so mundane as a `Missing Template`, `controller#action missing`, or `Undefined method .downcase for nil:NilClass`.
 
 Amber even parses and compiles templates and layout files which not only verifies that the code is calling methods and getters safely, it saves a lot of time during a request.
@@ -79,13 +79,13 @@ undefined method 'nam' for Domain (did you mean 'name'?)
 
 These compile time checks can save your sanity when an accidental typo slips its way into your routes file, or accidentally forgetting to commit a view template.
 
-# Open and welcoming dev team
+## Open and welcoming dev team
 The Amber project is _active_. Development on the tools, framework, libraries, and documentation is constant. Yet I've felt welcomed into the fold as an Amber contributor as the core team readily reviews and merges my pull requests, discusses framework direction and goals, and openly accepts suggestions and contributions from casual contributors as well as frequent benefactors.
 This picture is from the [Github Pulse](https://github.com/amberframework/amber/pulse/monthly) and shows how active the project has been this month:
 
 <img src="/assets/blog/amber-pulse.png" class="center"/>
 
-# Raw Speed
+## Raw Speed
 Last but certainly not least, thanks to Crystal, Amber is _**fast**_. The compiled web is real, and it’s far more friendly now than ever before.
 
 Check out this log excerpt from a project I've been working on:
@@ -164,7 +164,7 @@ Amazingly, because Amber views are compiled in, rendering a template and layout 
 
 No matter what your application is doing, Amber can do it _faster_.
 
-# Summary
+## Summary
 A lot of software is written for the web today. Ruby and Rails showed the world that development doesn't need to be painful for developers. Crystal is a language where development ease meets speed, and Amber is a framework built on that tradition. Developer friendliness meets raw speed and power, for the web. Or to borrow from Amber’s tag-line: Productivity. Performance. Happiness.
 
 [^select]: [Relevant log](https://gist.github.com/robacarp/d20ed807003d96e76a8538fab17e8af5#file-ab_crystal_logs-txt-L1)

--- a/_posts/2018-03-09-crystal-automated-release.md
+++ b/_posts/2018-03-09-crystal-automated-release.md
@@ -4,10 +4,10 @@ author: bcardiff
 description: "How the build process was updated and what else can be done"
 ---
 
-# Intro
+## Intro
 As we shared at [the end of 2017](https://crystal-lang.org/2017/12/19/this-is-not-a-new-years-resolution.html), we restarted this year working on a plan towards 1.0. Our first stop was improving the automation of releases. Thanks to the [donations](https://salt.bountysource.com/teams/crystal-lang) of December and part of January, we managed to put 80 hours of work into this. Thanks as usual for the help!
 
-# How things used to be
+## How things used to be
 For a long time, we managed Crystal’s release and distribution process through  [omnibus-crystal](https://github.com/crystal-lang/omnibus-crystal). Even though parts of the process were automatic, it involved many manual steps that required  launching virtual machines for different distros to generate pkg, deb, tar.gz, etc.
 
 This process used to be enough for our needs, when only one or two people (Ary and Waj) would be in charge of releasing versions of the language. But as the project and the core team grew, we were afraid that some parts of the process were not properly documented, depending on information sitting in their heads or work-of-art environments in their machines.
@@ -22,7 +22,7 @@ Despite all this manual process, @waj, @asterite, @jhass, @matiasgarciaisaia hav
 
 Some releases ago, @RX14 wrote a new build process to improve the packages for some Linux distros. As a result, we decided to drop omnibus in favor of a multi stage Docker image to ship a compiler with musl and an up to date LLVM version when possible.
 
-# What we want?
+## What we want?
 Our main goals are
 
 1. Fully automate the process of building released binaries, including the provisioning of the machine where they are built.
@@ -36,25 +36,25 @@ While trying to accomplish those goals we wanted to also address some technical 
 2. Avoid manual post release steps like publishing Docker images for CI.
 3. Update and unify versions of dependencies when possible.
 
-# What we did and what “surprises” we found?
+## What we did and what “surprises” we found?
 
-## Hello CircleCI 2.0
+### Hello CircleCI 2.0
 
 We migrated from a  CI setup that was running on CircleCI 1.0 to test OSX only to a CircleCI 2.0 workflow that will stress Linux32, Linux64 and OSX builds. Changing a cloud CI configuration it’s always a slow task: it feels like you send a script by email, then wait in queue, fail (many times) for silly details you missed, and retry once and again.
 
-## Nightly for Linux 64 bits
+### Nightly for Linux 64 bits
 
 After migrating the scripts that were running the CI we started to work on producing automated nightly images of the compiler for all supported platforms up to date.
 
 To build Linux 64 bits we now use the new [distribution-scripts](https://github.com/crystal-lang/distribution-scripts) created by @RX14. Moving to this was almost completely straightforward, except for some changes needed because the only time we had used those scripts was to release the 0.24.1 compiler based on 0.23.1 (in case you were wondering, 0.24.0 was effectively yanked).
 
-## Nightly for OSX
+### Nightly for OSX
 
 To build the osx compiler we migrated the [omnibus-crystal](https://github.com/crystal-lang/omnibus-crystal) repo to [distribution-scripts](https://github.com/crystal-lang/distribution-scripts). Having a single repo will simplify things eventually. We needed to tweak a bit how things used to be in order to avoid spending too much time of CircleCI [^update-ruby].
 
 Eventually, we could get completely rid of omnibus, but the main goal was to automate the process rather than changing the packaging.
 
-## Nightly for Linux 32 bits
+### Nightly for Linux 32 bits
 
 The `distribution-scripts` build system produces `x86_64` Linux packages. To get 32 bits there were a couple of alternatives.
 
@@ -70,23 +70,23 @@ So we couldn't use Crystal 0.24.1 (with the buggy GC version) inside the Docker 
 
 The bottom line: there are no 32-bit nightly packages for  0.24.2, but we should be able to introduce them in the future.
 
-## Nightly for Docs
+### Nightly for Docs
 
 Including the docs in the process is also neat. And it lets us stop publishing from Travis automatically (for tags and branches). This way now we are all able to preview nightly/tagged docs, jump to old unpublished versions and, most importantly, publish docs to the main site at the same time the packages will be published and not just when tagging the repo. This caused some confusion in the past because going to the site would say some things but packages would not reflect them.
 
-## Nightly for Docker
+### Nightly for Docker
 
 We wanted to go an additional step further and simplify how users could check if the nightly builds are working on their projects. So we put some work to publish Docker images tagged as nightly. With the fresh Linux packages made during the build we could install it and push a Docker image directly from CircleCI even if the package was not yet published in an APT repository. Note that these images have a compiler with release optimization, so the only difference with the official release will be the version description (of course, as long as the nightly built is performed on the same commit).
 
 We are going to publish `crystallang/crystal:nightly` and `crystallang/crystal:nightly-build` Docker images. The former should be able to compile apps that use the stdlib, the latter includes LLVM and dependencies needed to build the compiler.
 
-## Keep the lineage in the compiler repo
+### Keep the lineage in the compiler repo
 
 Each time a new Crystal compiler is released, the next one is usually built on the new one. The distribution and packaging solution usually will remain unchanged. In order not to lose track of the lineage of compilers it would be great to track exactly how each tag was built in the very same repository of the compiler. To accomplish this we made the distribution-scripts receive parameters to setup which existing Crystal compiler should be used to build the specific new commit or tag.
 
 The Crystal repo now includes a reference to a specific release of the distribution-scripts to use for nightly builds. Since the information about the previous compiler is stated now in the CI configuration, the lineage will be available in the repo itself from now on. A bonus point is that different branches in the future will not be constrained to use the “latest” version.
 
-## Tagged release build
+### Tagged release build
 
 The process of building a tagged commit is mostly the same. That is good! It’s the exhibit of a smoother build process.
 
@@ -100,7 +100,7 @@ Once CircleCI built distribution packages and docs what follows is:
 
 These steps are performed manually using [crystal-lang/crystal-dist](https://github.com/crystal-lang/crystal-dist) so the signing keys are kept safe. Eventually this repo might be join with `distribution-scripts` so all the pieces are kept in a single place.
 
-## Ecosystem tests
+### Ecosystem tests
 
 Nowadays, between Docker, Vagrant, CIs and other resources it’s possible to automate some smoke tests. We did some of this while releasing 0.24.1 and discovered some issues in the release before distributing it. But, sadly, we discovered those issues after tagging. With nightly packages available and some improvement in the tagging process we expect to run some smoke tests before releasing. This would help us detect problems earlier, maybe submitting PR/issues to the affected repositories. Although the compiler and the stdlib have a good amount of specs, for sure there are some interesting scenarios out there in the wild.
 
@@ -108,7 +108,7 @@ Today, we use [these ecosystem tests](https://github.com/bcardiff/test-ecosystem
 
 It’s not perfect, but it is an effort to at least know beforehand that something could be broken for the upcoming release.
 
-# How will we do things from now on?
+## How will we do things from now on?
 Let’s recap, what happens every night and for a proper release.
 
 Every night on master and every time a commit is tagged the following workflow will be executed.
@@ -136,7 +136,7 @@ There are two pending manual steps:
 
 Well, there are still a couple of things more to improve and get done. It never ends! Check the following section.
 
-# Automated Release Backlog
+## Automated Release Backlog
 
 * Update distribution-scripts to emit 32 bits binaries so the binary creation is fully automated.
 * We should be able to use the new Docker {version}-build images in the CI. That will remove the extra dependency of [jhass’ crystal build images](https://github.com/jhass/crystal-build-docker) that ran the CI until now.
@@ -147,11 +147,10 @@ Well, there are still a couple of things more to improve and get done. It never 
 * The creation of a patch of Homebrew formula could be automated so submitting a PR for the new release could be really fancy and, more importantly, unforgettable.
 * Shipping the compiler for more platforms is something that can be done, but as long as it can be automated. Eventually something that would make sense is to ship one version of the compiler that could be used to create packages for the different distros and use when possible native packages. That way the Crystal compiler package of each distro could be smaller and would play well regarding how dependencies need to be declared [^distro-deps]
 
-# Next steps
+## Next steps
 
 Our next goal is to research on improving the compiler's performance. For that, we will be making a pass on language semantics to round off some of the known problems we know are there. That will allows us to solidify the language so that we can guarantee no breaking-changes post 1.0.
 We have 41 hours left from January and 64 hours from donations received during February that we’ll invest during March on this. Please continue to [support our work](https://salt.bountysource.com/teams/crystal-lang), it makes a huge difference!
 
 [^update-ruby]: the Ruby versions available in OSX CircleCI VMs are limited. Installing & building a specific Ruby version takes some time [https://discuss.circleci.com/t/cache-of-installed-ruby/19606](https://discuss.circleci.com/t/cache-of-installed-ruby/19606)
 [^distro-deps]: [https://github.com/crystal-lang/crystal/issues/5650](https://github.com/crystal-lang/crystal/issues/5650)
-

--- a/_posts/2018-09-04-using-circleci-2.0-for-your-crystal-projects.md
+++ b/_posts/2018-09-04-using-circleci-2.0-for-your-crystal-projects.md
@@ -15,7 +15,7 @@ It’s time to review how to take advantage of the awesome features in CircleCI,
 
 As a case study, we will use a fake app that requires a database. The final example will cover a couple more of the basic needs and show a more realistic scenario.
 
-# Using Crystal latest release for builds
+## Using Crystal latest release for builds
 
 You probably use `$ shards` to install dependencies of your application and `$ crystal spec` to run specs.
 
@@ -47,7 +47,7 @@ workflows:
 
 It will show the specific compiler version used thanks to `crystal --version`. And you can force a specific version using `crystallang/crystal:VERSION` docker images instead of `crystallang/crystal:latest`.
 
-# Using a database server
+## Using a database server
 
 In your development environment you either have a database server installed or use docker and have probably mapped the ports to your host. So either way, if you use MySQL you can access the service as `localhost:3306`.
 
@@ -92,7 +92,7 @@ workflows:
 
 **Note:** The `dry` key is not standard. It’s just a placeholder of values that will be used multiple times later or that helps reading the job’s steps. If prefered, you can inline their contents directly.
 
-# Reduce CI delays
+## Reduce CI delays
 
 CircleCI caches docker images in each host and it even provides some [additional features](https://circleci.com/docs/2.0/docker-layer-caching/) to reduce downloading and building docker images. This greatly reduces the time spent in each build.
 
@@ -154,7 +154,7 @@ workflows:
 
 Notice how the cache key involves the checksum of the content of `shard.lock`. If you are using this for a shard, there should be no `shard.lock` file checked in and the `shard.yml` should be used instead.
 
-# Checked code against Crystal nightly
+## Checked code against Crystal nightly
 
 Crystal keeps evolving and, while the ecosystem is still growing, some dependencies may or may not need to be updated on every release. Some shards don’t have constant commit activity and CI usually runs on every push and PRs. This leads to the possibility of not running specs while the compiler and the std libs are still evolving and might break.
 

--- a/_posts/2019-05-08-formatting-pretty-numbers-for-humans.md
+++ b/_posts/2019-05-08-formatting-pretty-numbers-for-humans.md
@@ -11,13 +11,13 @@ Previously the options were using `#to_s` on various `Number` types or at best [
 
 When showing numbers in a user interface, they need to be understandable by human readers.
 
-# Format a Number
+## Format a Number
 
 Meet the new [`Number#format`](https://crystal-lang.org/api/0.28.0/Number.html#format%28separator%3D%26%2339%3B.%26%2339%3B%2Cdelimiter%3D%26%2339%3B%2C%26%2339%3B%2Cdecimal_places%3AInt%3F%3Dnil%2C%2A%2Cgroup%3AInt%3D3%2Conly_significant%3ABool%3Dfalse%29%3AString-instance-method) method.
 
 It allows printing numbers in a customizable format, that can represent the way that numbers are usually written for humans.
 
-## Number styles
+### Number styles
 
 Numbers can be formatted using configurable decimal separator and thousands delimiter:
 
@@ -38,7 +38,7 @@ There are many different styles used in different cultural contexts, and this me
 
 [*How the world separates its digits*](http://www.statisticalconsultants.co.nz/blog/how-the-world-separates-its-digits.html) provides an overview of international styles, and the [Wikipedia article on *Decimal Separators*](https://en.wikipedia.org/wiki/Decimal_separator) provides some more insight on this topic.
 
-## Decimal places
+### Decimal places
 
 Floating point numbers can produce a lot of decimal places when converted to a human-readable string. For user output such detail is usually a distraction and displaying a few decimal places is plenty.
 
@@ -59,7 +59,7 @@ The number of decimal places is fixed by default. Trailing zeros will only be om
 123_456.789.format(decimal_places: 6, only_significant: true) # => "123,456.789"
 ```
 
-# Humanize a Number
+## Humanize a Number
 
 When numbers of different orders of magnitude are put in relation, it's difficult to represent a large range of values in a meaningful way.
 
@@ -79,7 +79,7 @@ When `siginficant` is `true`, the value of `precision` is the fixed amount of de
 
 Quantifiers are by default the SI prefixes (`k`, `M`, `G`, etc.), but they're completely configurable, either by providing a list, or a proc.
 
-## Customizable quantifiers
+### Customizable quantifiers
 
 `Number#humanize` can take a proc argument that calculates the number of digits and the quantifier for a specific magnitude.
 
@@ -103,7 +103,7 @@ humanize_length(0.05)  # => "5.0 cm"
 humanize_length(0.001) # => "1.0 mm"
 ```
 
-# Humanize Bytes
+## Humanize Bytes
 
 The third method is [`Int#humanize_bytes`](https://crystal-lang.org/api/0.28.0/Int.html#humanize_bytes%28precision%3AInt%3D3%2Cseparator%3D%26%2339%3B.%26%2339%3B%2C%2A%2Csignificant%3ABool%3Dtrue%2Cformat%3ABinaryPrefixFormat%3D%3AIEC%29%3AString-instance-method) which allows formatting a number of bytes (for example memory size) in a typical format. It supports both IEC (`Ki`, `Mi`, `Gi`, `Ti`, `Pi`, `Ei`, `Zi`, `Yi`) and JEDEC (`K`, `M`, `G`, `T`, `P`, `E`, `Z`, `Y`) prefixes.
 
@@ -117,7 +117,7 @@ The third method is [`Int#humanize_bytes`](https://crystal-lang.org/api/0.28.0/I
 
 The [implementation of this method](https://github.com/crystal-lang/crystal/blob/639e4765f3f4137f90c5b7da24d8ccb5b0bfec35/src/humanize.cr#L304) is another example for a custom format based on `Numer#humanize`.
 
-# Summary
+## Summary
 
 These new methods provide great features for making numbers look pretty to the reader.
 

--- a/_posts/2020-08-20-preparing-our-shards-for-crystal-1.0.md
+++ b/_posts/2020-08-20-preparing-our-shards-for-crystal-1.0.md
@@ -11,7 +11,7 @@ Of course, the process described here is a bit opinionated. Depending on the rel
 
 When I say that the shard always has at least one dependency it is because the std-lib, and the language, act as yet another dependency.
 
-# Version checks
+## Version checks
 
 As dependencies evolve, it is up to you to decide whether to support just the latest release and force everybody to be on edge, or to support some older versions.
 
@@ -19,7 +19,7 @@ Thanks to the built-in reflection macros and methods as `has_constant?`, `has_me
 
 One other mechanism that is not as fancy, but simple, is the `compare_versions` macro. If `AwesomeDependency` defines a `AwesomeDependency::VERSION` (as it is encouraged by the init template), then `{% raw %}{% if compare_versions(AwesomeDependency::VERSION, "2.0.0") >= 0 %}{% endraw %}` is available to use features only on 2.0.0 or later releases.
 
-## Advertised version
+### Advertised version
 
 If the 3.x version of AwesomeDependency is being developed, we encourage you to set `AwesomeDependency::VERSION` to `"3.0.0-dev"` or something alike. `"3.0.0"` may be good enough, but some prefer to keep that value for the tagged release only.
 
@@ -27,7 +27,7 @@ If the `AwesomeDependency::VERSION` is not increased _during_ the development of
 
 If `AwesomeDependency::VERSION = "3.0.0-dev"` and we want to start supporting that version in our development branch, we will need to use something like `{% raw %}{% if compare_versions(AwesomeDependency::VERSION, "3.0.0-0") >= 0 %}{% endraw %}`, with a trailing `-0`. This is because `3.0.0-0 < 3.0.0-a < 3.0.0-dev < 3.0.0-z < 3.0.0`.
 
-# Declaring dependencies
+## Declaring dependencies
 
 At this point, we need to mention how dependencies can be declared. As mentioned before, on a tagged release, the `shard.yml` acts as a contract. This contract states what are the supported versions of each dependency. Shards allows us to declare dependencies, not only as version ranges, but also on a branch, or with no version. Still, I would recommend using version ranges, with lower and upper bound versions, on every formal release of a shard. The other variations should be limited to applications with a `shard.lock` or work in progress.
 
@@ -54,7 +54,7 @@ If this mechanism is used with a cron on the CI we will have nightly checks of t
 
 Another alternative would be to set version ranges on dependencies only when releasing our shard. This would leave unrestricted dependencies in our development branch, but I think that that will require more work upon release, and it will still require the override to avoid picking the latest release by default.
 
-# Moving to Crystal 1.0
+## Moving to Crystal 1.0
 
 So far we haven’t mentioned Crystal 1.0. What's the deal with this release or any other major releases? The shards out in the wild declare which std-lib and language version they work with.
 
@@ -70,7 +70,7 @@ To avoid locking us in this, or other major Crystal release, the `--ignore-cryst
 
 You can set the `SHARDS_OPTS` environment variable to `--ignore-crystal-version` in your CI if the `shards install` command is performed implicitly along the way.
 
-# Preparing all the ecosystem for Crystal 1.0
+## Preparing all the ecosystem for Crystal 1.0
 
 Let's revisit the whole state with a more concrete hypothetical (and pessimistic) example. We are the authors of `BelovedShard` that depends on `AwesomeShard`. So far everything is working on Crystal 0.35. `BelovedShard` is in `1.5.0` and `AwesomeShard` is in `2.2.3`.
 
@@ -128,9 +128,8 @@ While Crystal 1.0.0-dev keeps evolving, we can iterate on both shards.
 
 Once Crystal 1.0 is released, each shard will make the explicit decision about which version of the std-lib and language is supported. This will trigger changes in the `shard.yml` and maybe some code clean-ups.
 
-# Closing thoughts
+## Closing thoughts
 
 There are other workflows to keep things up to date. This is just one option.
 
 As a community, other patterns might appear or be preferred in the long run. The recent changes in Shards aimed to provide at least one option that works and can be adapted to some extent.
-

--- a/_posts/2020-11-19-organising-raw-crystal.md
+++ b/_posts/2020-11-19-organising-raw-crystal.md
@@ -63,7 +63,7 @@ Attendees are registering from all over the world, with some fearless folks base
 <img src="/assets/blog/2020-11-raw-crystal-geo.png" width="617"  class="center" alt="Registrations across the word: 28 registrations in North America, 43 in Europe, 8 in South America, 7 between Asia and Australia."/>
 Around 50% of the registrations come from Europe; 30% of the registrations come from North America.
 
-# What's next?
+## What's next?
 A lot has been decided already, but I'm still working out a few crucial details - mainly, which software we'll be using to run and record the event.
 
 I am also looking forward to finalising the speakers line-up for you to see and plan your conference day.

--- a/_posts/2021-04-22-crystal-conference-1.0-launch.md
+++ b/_posts/2021-04-22-crystal-conference-1.0-launch.md
@@ -12,7 +12,7 @@ Going forward, we want to continue the evolution of the language on delighting i
 
 The online conference takes place on **July 8, 2021**.
 
-### Why a Crystal 1.0 Launch Conference?
+## Why a Crystal 1.0 Launch Conference?
 
 * Many people have been a part of the Crystal universe for years, and many others are only now hearing about it. A conference is an ideal vehicle for those who’ve been around for a long time to show the newcomers what it’s all about.
 * Over the years, organizations and individuals have trusted Crystal and used it for their projects, some of them experiments and some of them core to their business. We want to give them a platform to share their stories in the hopes that it inspires others to follow in their footsteps.
@@ -26,7 +26,7 @@ See you there!
 
 ---
 
-### Call for Talks
+## Call for Talks
 
 We are inviting Crystal users, developers, and contributors in general to submit their talks for the Crystal 1.0 Conference.
 

--- a/_posts/2021-06-01-behind-the-scenes.md
+++ b/_posts/2021-06-01-behind-the-scenes.md
@@ -11,19 +11,19 @@ We’ve already mentioned important [changes in the Core Team composition](https
 
 Thus, we have set the following list of priorities to help us steer our actions:
 
-### Transparency
+## Transparency
 
 Transparency has always been a cornerstone of how Crystal is led and developed. It is very important for us to continue along this line, and we’re thinking of new ways to let our community know how the decision processes work in the governance of Crystal. In this respect we took two steps: first, we published the [Crystal governance document](https://crystal-lang.org/reference/governance.html), where we outlined the bodies in charge of running Crystal, together with the processes we follow for making decisions about the language. Second, we published a new [Team page](https://crystal-lang.org/team), where everyone can see at a glance who is involved in the day-to-day management of the language.
 
-### Growing the Core Team
+## Growing the Core Team
 
 With a few members becoming inactive, we wanted to grow the number of core members to keep our pace and, if possible, increase it. In this respect, we are very happy to announce that [Oleh Prypin (oprypin)](https://github.com/oprypin/) is our newest addition to the team, and our second run of voting in a member in accordance with the new governance (the first one being for my own inclusion). Oleh has been an active member of our community since 2015, and has shown a great capacity to improve the language and its ecosystem in every one of his contributions.
 
-### Fixed releases
+## Fixed releases
 
 We want the community to know when to expect each new release, so we are working on ways to make them more regular, with a freeze period of 2-3 weeks in order to let people update their shards and programs, and work on possible regressions. We are still working on the details, but likely there will be three months between a 1.x and 1.(x+1) release.
 
-### Native support on Windows and the newly released Macs
+## Native support on Windows and the newly released Macs
 
 Aiming for wider adoption, we want every major platform to have a native Crystal compiler. We have made significant steps towards Windows support, with the sockets library being almost ready. As for the ARM Macs, we need to get our compiler working with the latest versions of the LLVM framework, a hard stone to crack in which we have already made good progress.
 

--- a/_posts/2021-12-29-crystal-i.md
+++ b/_posts/2021-12-29-crystal-i.md
@@ -10,7 +10,7 @@ The awaited Crystal interpreter has been [merged](https://github.com/crystal-lan
 This post doubles as a F.A.Q. for this special feature. Let's start from the very beginning:
 
 
-# Why Crystal needs an interpreter
+## Why Crystal needs an interpreter
 
 While many will find this obvious, it's useful to point out two specific features that an interpreter might enable:
 
@@ -18,19 +18,19 @@ While many will find this obvious, it's useful to point out two specific feature
 2. An interpreter improves the experience of debugging, being an ad-hoc tool to the language (unlike the generic `lldb`).
 
 
-# What is the current status?
+## What is the current status?
 
 The interpreter is currently on an experimental phase, with lots of [missing bits](https://github.com/crystal-lang/crystal/issues/11555). The reason to merge it at this early stage is to enable a proper discussion of interpreter-related PRs and speed up its development a bit. For those willing to try it out, we welcome interpreter-related issues taking into consideration the already known issues aforelinked.
 
 
-# How does it work?
+## How does it work?
 
 The [original PR](https://github.com/crystal-lang/crystal/pull/11159) answers it:
 
 > When running in interpreted mode, semantic analysis is done as usual, but instead of then using LLVM to generate code, we compile code to bytecode (custom bytecode defined in this PR, totally unrelated to LLVM). Then there's an interpreter that understands this bytecode.
 
 
-# How do I invoke it?
+## How do I invoke it?
 
 ⚠️ This is not set in stone!
 
@@ -58,7 +58,7 @@ icr:1:0> File.read_lines("/tmp/hello")
 
 (Note: the highlighting is not yet part of the interpreter.)
 
-# Debugging a program
+## Debugging a program
 
 In any of these two modes, you can use `debugger` in your code to debug it at that point. This is similar to Ruby's `pry`. There you can use these commands (similar to `pry` also):
 
@@ -108,12 +108,12 @@ pry> objects
 {"done"}
 ```
 
-# How much faster does the interpreter load a program?
+## How much faster does the interpreter load a program?
 
 We're definitely missing benchmarks, more so given that not many shards can be successfully interpreted. Testing on a few random files from the standard library and [Crystal Patterns](https://github.com/crystal-community/crystal-patterns), it loads them (and _executes_ them, see below) between 50 and 75% faster than it takes when compiling them (comparing `time crystal <file>` vs. `time crystal i <file>`). This depends significantly on how much time Crystal takes on the common steps to the compiler and the interpreter, like parsing and semantic analysis.
 
 
-# How fast (or slow) does it run?
+## How fast (or slow) does it run?
 
 As Ary, its creator, [showed](https://www.youtube.com/watch?v=een_W1YEICw) in [Crystal Conf 1.0](https://www.crystal-lang.org/conference/), it runs sufficiently fast—for an interpreter that is. Of course, it's not nearly as efficient as a mature interpreter implementation like Ruby's, yet in our preliminary tests it runs fast enough for the expected use cases. For instance, it can handle millions of integer additions within the second. This said, using the interpreter for processing intensive tasks is definitively discouraged, as that's the task for a compiled program.
 


### PR DESCRIPTION
All headers in markdown posts are normalized to h2 level.

Co-authored-by: Carlos Zillner <czillner@manas.com.ar>