### PR TITLE
Fixes in team page

### DIFF
--- a/team/index.html
+++ b/team/index.html
@@ -57,8 +57,13 @@ css: team
 <section class="list grid sidebar">
   <div class="info">
     <h2>Community Moderators</h2>
-    <p>These awesome people have served as core team members in the past. They are listed here to record and honor their contributions.</p>
-    <p>If you want to become a contributor, see our <a href="https://github.com/crystal-lang/crystal/blob/master/CONTRIBUTING.md" target="_blank">Contributing Instructions</a> and <a href="https://github.com/crystal-lang/crystal/blob/master/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a>.</p>
+    <p>
+      Some experienced members of the community help moderating the community channels.
+      They have the <a href="https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization">Triage role</a> on GitHub which gives them the ability to assign labels, open & close issues/PRs, apply milestones, mark duplicates, assign issues/PRs and request reviews.
+    </p>
+    <p>
+      If you think you qualify and want to apply to become one, please don't hesitate to contact the core team at <a href="mailto:crystal@manas.tech">crystal@manas.tech</a>.
+    </p>
   </div>
   <ul class="cards">
     {% for member in site.data.team.moderators %}
@@ -72,9 +77,12 @@ css: team
 <section class="list grid sidebar">
   <div class="info">
     <h2>Contributors</h2>
-    <p>These awesome people have served as core team members in the past. They are listed here to record and honor their contributions.</p>
-    <p>If you think you qualify, please:</p>
-    <a href="mailto:crystal@manas.tech" class="hex btn shadow"><span>Contact Us</span></a>
+    <p>
+      Besides those that are explicitly named, this is a call out to
+      <a href="https://github.com/crystal-lang/crystal/graphs/contributors">hundreds more contributors</a>
+      who put their work into the project.
+    </p>
+    <p>If you want to become a contributor, see our <a href="https://github.com/crystal-lang/crystal/blob/master/CONTRIBUTING.md" target="_blank">Contributing Instructions</a> and <a href="https://github.com/crystal-lang/crystal/blob/master/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a>.</p>
   </div>
   <img src="https://opencollective.com/crystal-lang/contributors.svg?width=960">
 </section>

--- a/team/index.html
+++ b/team/index.html
@@ -5,14 +5,20 @@ description: >
 css: team
 ---
 
+<section class="list grid sidebar">
+  <div class="info">
+    <h2>Core Team</h2>
+    <p>The Core Team manages the development of Crystal and its ecosystem.</p>
+  </div>
 
-<ul class="cards">
-  {% for member in site.data.team.core %}
-    {% if member[1].status == "active" %}
-      {% include member_profile.html %}
-    {% endif %}
-  {% endfor %}
-</ul>
+  <ul class="cards">
+    {% for member in site.data.team.core %}
+      {% if member[1].status == "active" %}
+        {% include member_profile.html %}
+      {% endif %}
+    {% endfor %}
+  </ul>
+</section>
 
 <section class="alumni">
   <h2>Alumni</h2>


### PR DESCRIPTION
This PR creates a section for core team members, and fixes and improve the text for moderators and contributors. There are two missing bits:
- A sponsors section
- A better design for the last two sections, since there's too much text.