### PR TITLE
Extending FAQ info in sponsors

### DIFF
--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -47,13 +47,40 @@ custom_body_classes: sponsors
       <div class="faq">
         <h2>FAQ</h2>
 
-        <p class="bold">What is this list?</p>
-        <p>These are the companies and individuals contributing a monthly amount to help sustain Crystal's development. See the Open Collective campaign for more details.</p>
-
-        <p class="bold">I am a sponsor contributing $5/month, but my URL is not listed</p>
-        <p>We grab the website and avatar from your Open Collective profile or your Bountysource profile. If that fails, we try to use your GitHub or Twitter accounts listed in that same profile. We update the current sponsors in this page every other week.</p>
-        <p>If there is any mismatch information you would like to correct, please contact us.</p>
-      </div>
+        <p>
+          <h3>What is this list?</h3>
+          These are the companies and individuals contributing to help sustain Crystal's development. See
+          the <a class="contributing-link" href="https://opencollective.com/crystal-lang" target="_blank">Open Collective campaign</a> for more details.
+        </p>
+    
+        <p>
+          <h3>I am a sponsor contributing $5/month, but my URL is not listed</h3>
+          We grab the website and avatar from your
+          <a class="contributing-link" href="https://opencollective.com" target="_blank">Open Collective profile</a>. If that fails, we try to use your GitHub or Twitter accounts listed in
+          that same profile.
+        </p>
+    
+        <p>
+          <h3>When is this page updated?</h3>
+          We update the current sponsors in this page weekly.
+        </p>
+    
+        <p>
+          <h3>How is the list ordered?</h3>
+          It is ordered by level of contribution and total amount contributed so far. Columns are sortable.
+        </p>
+    
+        <p>
+          <h3>How long are contributors listed?</h3>
+          Contributors are listed forever, but after three months of the last payment they are considered as contributing $0 (that is, no link is shown).
+        </p>
+    
+        <p>
+          <h3>There seems to be an error, how can I fix it?</h3>
+          If there is any mismatch information you would like to correct, please <a class="contributing-link" href="mailto:crystal@manas.tech">contact
+            us</a>.
+        </p>
+      </div>    
     </div>
 
     <table id="sponsors-tbl">


### PR DESCRIPTION
Bringing back some missing information. TODO: Ideally, the FAQ should be collapsed instead of shown by default.