### PR TITLE
Add tutorial to learning page

### DIFF
--- a/learning/index.html
+++ b/learning/index.html
@@ -1,8 +1,17 @@
 ---
-title: External resources
-description: Here is a collection of learning material from third parties that might help you master the language.
+title: Learning
+description: Here is a collection of learning material that can help you get familiar and master the language.
 ---
 <div class="container">
+
+  {% include community_row.html
+    title="Language Introduction"
+    divId="tutorial-introduction"
+    content="This course is targeted at novice Crystal programmers and conveys a basic understanding of the language's core concepts. Prior programming experience is recommended, but not required. This course can help you learn your first programming language."
+    link_text="Tutorial: Language Introduction"
+    url="https://crystal-lang.org/reference/1.6/tutorials/basics/index.html"
+    icon="link"
+  %}
 
 {% include community_row.html
   title="Crystal Programming"


### PR DESCRIPTION
I think it makes sense to have *all* relevant learning materials linked on that page, not just those by third parties. For a users who's interested in learning Crystal it hardly matters whether it's an internal resource or not.

This patch changes the title and intro of the page to match that and adds a link to the tutorial in crystal-book.