### PR TITLE
Introduce callouts plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -82,3 +82,5 @@ kramdown:
       css_class: code_section
 
 repository: crystal-lang/crystal-website
+
+callouts: ["NOTE"]

--- a/_includes/callout.html
+++ b/_includes/callout.html
@@ -1,0 +1,6 @@
+<div class="callout callout--{{ include.callout }}">
+  {% if include.title %}
+    <h4>{{ include.title }}</h4>
+  {% endif %}
+  {{ include.content | markdownify }}
+</div>

--- a/_plugins/callouts.rb
+++ b/_plugins/callouts.rb
@@ -1,0 +1,63 @@
+module Jekyll
+  class CalloutsConverter < Jekyll::Generator
+    priority :low
+
+    def initialize(config)
+      callout_names = config["callouts"]
+      if callout_names && !callout_names.empty?
+        @regex = /(^ {0,3}>\s*)\*\*(#{callout_names.join("|") {|n| Regexp.escape(n)}}):\*\*((?:[\t ]+[^\n]*)?)(\n(?:^ {0,3}>[^\n]*)*)/m
+      else
+        @regex = nil
+      end
+    end
+
+    def generate(site)
+      return unless @regex
+      @site = site
+      site.collections.each do |_, collection|
+        collection.docs.each do |post|
+          convert_callouts(post) if post.extname == '.md'
+        end
+      end
+    end
+
+    private
+
+    FOLLOW_LINE_REGEX = /\n {0,3}>/
+
+    def convert_callouts(post)
+      post.content = post.content.gsub(@regex) {
+        match = $~
+        render_include(match[2], match[3].lstrip, match[4].gsub(FOLLOW_LINE_REGEX, "\n").lstrip)
+      }
+    end
+
+    def render_markdown(source)
+      @site.find_converter_instance(
+        Jekyll::Converters::Markdown
+      ).convert(source)
+    end
+
+    DEFAULT_INCLUDE_PATH = "callout.html"
+
+    def render_include(callout, title, content)
+      template = callout.downcase
+      template.tr!("- ", "__")
+      file = "callouts/#{template}.html"
+
+      unless locate_include_file(file)
+        file = DEFAULT_INCLUDE_PATH
+      end
+
+      %({% include #{file} callout="#{template}" title=#{title.inspect} content=#{content.inspect} %})
+    end
+
+    def locate_include_file(file)
+      @site.includes_load_paths.each do |dir|
+        path = Jekyll::PathManager.join(dir, file)
+        return path if File.file?(path)
+      end
+      nil
+    end
+  end
+end

--- a/_posts/2020-08-06-shards-0.12.0-released.md
+++ b/_posts/2020-08-06-shards-0.12.0-released.md
@@ -9,7 +9,7 @@ author: bcardiff
 
 This release of shards is focused on solving some papercuts issues and adding features that will come in handy to enable a healthy package ecosystem that will work against different versions of the language, plus reducing the friction of working on fixes here and there. Don't miss out on the rest of the [release changelog](https://github.com/crystal-lang/shards/releases/tag/v0.12.0).
 
-> NOTE: To use this new release you will need to build shards from sources or use a nightly Crystal release until 1.0.0-pre1 is tagged.
+> **NOTE:** To use this new release you will need to build shards from sources or use a nightly Crystal release until 1.0.0-pre1 is tagged.
 
 You shall notice better error messages when a dependency’s `shard.yml` file triggers an error thanks to [#408](https://github.com/crystal-lang/shards/pull/408).
 

--- a/_posts/2022-06-13-latests-from-the-team.md
+++ b/_posts/2022-06-13-latests-from-the-team.md
@@ -11,14 +11,14 @@ Here we tell the community what's been on the team's plate for the last couple o
 
 We directed efforts to [improve the documentation](https://github.com/crystal-lang/crystal-book/pulls?page=1&q=is%3Apr++merged%3A%3E%3D2022-01-01), since that's where users are guided to when first learning the language. This is part of an on-going task to improve newcomers experience with the language.
 
-> **Shameless plug #1** <br/>
+> **NOTE:** Shameless plug #1
 > Our @ftarulla is writting about his experience with Crystal in his [dev.to channel](https://dev.to/franciscello/) that you can follow.
 
 ## A long and exciting hiring process
 
 As you probably know already, Crystal's been actively working to [grow its team](https://forum.crystal-lang.org/t/call-for-crystal-language-devs/4366). We can't share the news just yet, but it was interesting to see many familiar faces in the process! Hiring processes can certainly be intensive! And we're not even finished yet… 🥵 But it will definitively be worth the effort. More on that on a separate post 😀
 
-> **Shameless plug #2** <br/>
+> **NOTE:** Shameless plug #2
 > [Manas.Tech](https://manas.tech) is still hiring in a number of other [positions](https://manas.tech/join)!
 
 ## Garbage Collection

--- a/_sass/components/_callout.scss
+++ b/_sass/components/_callout.scss
@@ -1,0 +1,13 @@
+.callout {
+  background: rgba(0,0,0,0.05);
+  padding: 1em;
+
+  h4:first-child {
+    font-size: 1.2em;
+    margin: 0;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/_sass/stylesheet.scss
+++ b/_sass/stylesheet.scss
@@ -15,6 +15,7 @@
 @import "sprites";
 
 // Imports for components
+@import "components/callout";
 @import "components/code_block";
 @import "components/footer";
 

--- a/_style_guide/typography-callout-generic-title.md
+++ b/_style_guide/typography-callout-generic-title.md
@@ -1,0 +1,7 @@
+---
+title: "Callout: Generic (with title)"
+type: typography
+---
+
+> **NOTE:** Important notice
+> To use this new release you will need to build shards from sources or use a nightly Crystal release until 1.0.0-pre1 is tagged.

--- a/_style_guide/typography-callout-generic.md
+++ b/_style_guide/typography-callout-generic.md
@@ -1,0 +1,7 @@
+---
+title: "Callout: Generic"
+type: typography
+---
+
+> **NOTE:**
+> To use this new release you will need to build shards from sources or use a nightly Crystal release until 1.0.0-pre1 is tagged.


### PR DESCRIPTION
This plugin provides a feature for rendering callouts / admonitions from markdown content. It uses standard markdown syntax: the combination of blockquote and a designator string (surrounded by double asterisk) indicates a callout.

The format is the same as for the `markdown-callouts` extension we introduced in https://github.com/crystal-lang/crystal-book/pull/630.
The only difference is that this plugin only recognizes the blockquote syntax, not the single-paragraph variant without blockquote.

Preview on a blog post: https://deploy-preview-375--crystal-website.netlify.app/2022/06/13/latests-from-the-team/