### PR TITLE
Compress sass output

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,6 +73,9 @@ exclude:
 - vendor
 - netlify.toml
 
+sass:
+  style: compressed
+
 highlighter: rouge
 markdown: kramdown
 kramdown:


### PR DESCRIPTION
This reduces the output of the compiled stylesheet from 179KB to 148KB.