### PR TITLE
Fix layout for install pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,12 +42,12 @@ defaults:
       is_post: true
   -
     scope:
-      path: "install"
+      path: "install/**/*{.html,.md}"
       type: pages
     values:
       image: /assets/icon.png
       layout: install
-      permalink: /install/:basename/
+      permalink: /:path/:basename/
 
   - scope:
       path: ""


### PR DESCRIPTION
Fixes #382

The added scopes for `.html` files in #352 surpassed the install pages scope which assigns the `install` layout. It appears that increasing specificity re-establishes the install scope.