### PR TITLE
Add verification backlink to fosstodon account

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,8 @@ custom_body_classes:
       </div>
     </div>
   </div>
-
 </div>
+
+<a href="https://fosstodon.org/@CrystalLanguage" rel="me" style="display: none;"></a>
 
 <script src="https://d3js.org/d3.v3.min.js"></script>


### PR DESCRIPTION
This link is invisible for now and just serves for verification. We'll later include it properly into the site.