### PR TITLE
Migrate to Google Analytics v4

### DIFF
--- a/_includes/site/google_analytics.html
+++ b/_includes/site/google_analytics.html
@@ -1,9 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-D3KP40BWCR"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  ga('create', 'UA-42353458-1', 'auto');
-  ga('send', 'pageview');
+  gtag('config', 'G-D3KP40BWCR');
 </script>


### PR DESCRIPTION
Google is sunsetting Universal Analytics in favour of Google Analytics v4. This commit updates the analytics code to report to the new GAv4 property.