### PR TITLE
Fix download.opensuse.org URLs with slashes in project path

### DIFF
--- a/_includes/install/from_obs_deb.md
+++ b/_includes/install/from_obs_deb.md
@@ -26,7 +26,7 @@ You can find available options on the [installation page at OBS](https://softwar
 echo "deb http://download.opensuse.org/repositories/devel:/languages:/crystal/{REPOSITORY}/ /" | sudo tee /etc/apt/sources.list.d/crystal.list
 
 # Add signing key
-curl -fsSL https://download.opensuse.org/repositories/devel:languages:crystal/{REPOSITORY}/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/crystal.gpg > /dev/null
+curl -fsSL https://download.opensuse.org/repositories/devel:/languages:/crystal/{REPOSITORY}/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/crystal.gpg > /dev/null
 ```
 
 Once the repository is configured you're ready to install Crystal:

--- a/_includes/install/from_obs_rpm.md
+++ b/_includes/install/from_obs_rpm.md
@@ -27,9 +27,9 @@ cat > /etc/yum.repos.d/crystal.repo <<END
 [crystal]
 name=Crystal
 type=rpm-md
-baseurl=https://download.opensuse.org/repositories/devel:languages:crystal/{REPOSITORY}/
+baseurl=https://download.opensuse.org/repositories/devel:/languages:/crystal/{REPOSITORY}/
 gpgcheck=1
-gpgkey=https://download.opensuse.org/repositories/devel:languages:crystal/{REPOSITORY}/repodata/repomd.xml.key
+gpgkey=https://download.opensuse.org/repositories/devel:/languages:/crystal/{REPOSITORY}/repodata/repomd.xml.key
 enabled=1
 END
 

--- a/install.sh
+++ b/install.sh
@@ -196,8 +196,8 @@ _install_apt() {
   fi
 
   # Add repo signign key
-  wget -qO- https://download.opensuse.org/repositories/${OBS_PROJECT}/${DISTRO_REPO}/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/devel_languages_crystal.gpg > /dev/null
-  echo "deb http://download.opensuse.org/repositories/${OBS_PROJECT}/${DISTRO_REPO}/ /" | tee /etc/apt/sources.list.d/crystal.list
+  wget -qO- https://download.opensuse.org/repositories/${OBS_PROJECT//:/:\/}/${DISTRO_REPO}/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/devel_languages_crystal.gpg > /dev/null
+  echo "deb http://download.opensuse.org/repositories/${OBS_PROJECT//:/:\/}/${DISTRO_REPO}/ /" | tee /etc/apt/sources.list.d/crystal.list
   apt-get update
 
   if [[ "$CRYSTAL_VERSION" == "latest" ]]; then
@@ -218,9 +218,9 @@ _install_yum() {
 [crystal]
 name=Crystal (${DISTRO_REPO})
 type=rpm-md
-baseurl=https://download.opensuse.org/repositories/${OBS_PROJECT}/${DISTRO_REPO}/
+baseurl=https://download.opensuse.org/repositories/${OBS_PROJECT//:/:\/}/${DISTRO_REPO}/
 gpgcheck=1
-gpgkey=https://download.opensuse.org/repositories/${OBS_PROJECT}/${DISTRO_REPO}/repodata/repomd.xml.key
+gpgkey=https://download.opensuse.org/repositories/${OBS_PROJECT//:/:\/}/${DISTRO_REPO}/repodata/repomd.xml.key
 enabled=1
 EOF
 
@@ -234,7 +234,7 @@ EOF
 _install_dnf() {
   _install_rpm_key
 
-  dnf config-manager --add-repo https://download.opensuse.org/repositories/${OBS_PROJECT}/$DISTRO_REPO/${OBS_PROJECT}.repo
+  dnf config-manager --add-repo https://download.opensuse.org/repositories/${OBS_PROJECT//:/:\/}/$DISTRO_REPO/${OBS_PROJECT}.repo
 
   if [[ "$CRYSTAL_VERSION" == "latest" ]]; then
     dnf install -y crystal
@@ -250,7 +250,7 @@ _install_zypper() {
   fi
 
   _install_rpm_key
-  zypper --non-interactive addrepo https://download.opensuse.org/repositories/${OBS_PROJECT}/$DISTRO_REPO/${OBS_PROJECT}.repo
+  zypper --non-interactive addrepo https://download.opensuse.org/repositories/${OBS_PROJECT//:/:\/}/$DISTRO_REPO/${OBS_PROJECT}.repo
   zypper --non-interactive refresh
 
   if [[ "$CRYSTAL_VERSION" == "latest" ]]; then


### PR DESCRIPTION
The canononical URLs contain slashes after each `:` separator. The URLs without slashes redirect to the version with slashes.
This avoids unnecessary redirects and improves resiliency during service disruptions (crystal-lang/crystal#13497).

Includes changes from crystal-lang/distribution-scripts#247