### PR TITLE
commenting_out_miskate_fix

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -4,7 +4,7 @@ layout: skeleton
 # Inheriting layouts implement the page header and content.
 ---
 <div class="wrapper {{ page.custom_body_classes | join: ' '}}">
-  {#% include site/conference_header.html %#}
+  <!-- {% include site/conference_header.html %} -->
   {% include site/nav.html %}
 
   {{ content }}


### PR DESCRIPTION
this is the fix of issue https://github.com/crystal-lang/crystal-website/issues/513

with the conference header should be

![Screenshot 2023-11-05 at 10 33 52 PM](https://github.com/crystal-lang/crystal-website/assets/3889468/ced98f0a-7421-4ae9-8189-27d56fd0bde3)

I commenting out html way
![Screenshot 2023-11-05 at 10 23 34 PM](https://github.com/crystal-lang/crystal-website/assets/3889468/d1db29c4-1c96-4a7b-8e3b-84b67b8da740)


Thank you, it now works well.