### PR TITLE
Allow resizing preview vierport in style guide

### DIFF
--- a/_sass/pages/_styleguide.scss
+++ b/_sass/pages/_styleguide.scss
@@ -10,8 +10,10 @@
     border-radius: 0.425rem;
     padding: var(--padding-sm);
 
-    &.wide {
-      max-width: unset;
+    max-width: unset;
+
+    &:not(.wide) {
+      width: var(--content-width);
     }
   }
 
@@ -22,4 +24,9 @@
       white-space: pre-line;
     }
   }
+}
+
+.styleguide-preview {
+  resize: both;
+  overflow: scroll;
 }


### PR DESCRIPTION
With this change you can drag the size of the boxes on the style guide to see how the components behave with different spaces.

![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/eaf88f36-6e79-4704-894c-6e1e9f597fdf)
