### PR TITLE
Use `page_title` for book page

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: base
 
 <article class="post" itemscope itemtype="https://schema.org/Article">
   <hgroup>
-    <h1 class="post-title">{{ page.title }}</h1>
+    <h1 class="post-title">{{ page.page_title | default: page.title }}</h1>
     {% if page.subtitle %}
     <h1 class="subtitle">{{ page.subtitle }}</h1>
     {% endif %}

--- a/_layouts/wide.html
+++ b/_layouts/wide.html
@@ -3,7 +3,7 @@ layout: base
 ---
 
 <header>
-  <h1>{{ page.title }}</h1>
+  <h1>{{ page.page_title | default: page.title }}</h1>
 </header>
 
 {{ content }}

--- a/_pages/learning/crystal_programming.html
+++ b/_pages/learning/crystal_programming.html
@@ -1,5 +1,6 @@
 ---
-title: "Building efficient, safe, and readable web and CLI applications with Crystal"
+title: Crystal Programming
+page_title: "Building efficient, safe, and readable web and CLI applications with Crystal"
 layout: book
 
 book:


### PR DESCRIPTION
The `page_title` property is already used in other places (for example the install layout).
It allows using a different title on the page itself, in contrast to other places where `title` refers to the page. For the book page, we want the external title to be `Crystal Programming` (that's the name of the book), but the book page itself has a longer title.