### PR TITLE
Left align `.content`

### DIFF
--- a/_sass/components/_content.scss
+++ b/_sass/components/_content.scss
@@ -6,5 +6,5 @@
   }
 
   max-width: var(--content-width);
-  margin-inline: auto;
+  margin-inline-end: auto;
 }


### PR DESCRIPTION
Content should be left aligned to form a common edge with the header area (which can be wider)

before:
![image](https://github.com/crystal-lang/crystal-website/assets/466378/2da090d2-b3e9-43e6-8666-aae8e9792064)

after:
![image](https://github.com/crystal-lang/crystal-website/assets/466378/a51b1846-c5e5-46df-b710-30cbacd4b6a9)
