### PR TITLE
Standardize on `page_title` property

### DIFF
--- a/_includes/site/page-header.html
+++ b/_includes/site/page-header.html
@@ -1,5 +1,5 @@
 <header>
-  <h1>{{ include.header_title | default: page.header_title | default: page.title }}</h1>
+  <h1>{{ include.page_title | default: page.page_title | default: page.title }}</h1>
 
   <div class="page-description">
     {{ page.description }}

--- a/_pages/releases.html
+++ b/_pages/releases.html
@@ -1,6 +1,6 @@
 ---
 title: Releases
-header_title: |
+page_title: |
   Releases
   <a class="icon" href="/releases/feed.xml" rel="alternate" title="Newsfeed for Crystal releases" aria-label="Releases newsfeed" type="application/atom+xml">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><use href="#icon-rss"></use></svg>


### PR DESCRIPTION
In the same vain as #524 this unifies the `header_title` and `page_title` properties into the latter (which is used more commonly).