### PR TITLE
Add `jekyll-relative-links` plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'kramdown-parser-gfm'
 group :jekyll_plugins do
   gem 'jekyll-seo-tag'
   gem 'jekyll-redirect-from'
+  gem 'jekyll-relative-links'
 end
 
 # Webrick is used for `jekyll serve`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       webrick (~> 1.7)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
+    jekyll-relative-links (0.7.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
@@ -72,6 +74,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.3)
   jekyll-redirect-from
+  jekyll-relative-links
   jekyll-seo-tag
   kramdown-parser-gfm
   webrick (~> 1.7)

--- a/_config.yml
+++ b/_config.yml
@@ -87,3 +87,7 @@ kramdown:
 repository: crystal-lang/crystal-website
 
 callouts: ["NOTE"]
+
+relative_links:
+  enabled:     true
+  collections: true

--- a/_pages/summerofcode.md
+++ b/_pages/summerofcode.md
@@ -108,7 +108,7 @@ ecosystem ^_^).
 
 ## Next steps
 
-If you are interested, join the [community](/community) through your
+If you are interested, join the [community](/_pages/community.html) through your
 channel of preference. You're welcome whether you participate in the Google
 Summer of Code or not.
 

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -12,7 +12,7 @@ layout: page-wide
 
 The *Core Team* leads the development of Crystal and its ecosystem under the
 guidance of the *Steering Council*. Both bodies are defined in the
-[Governance document](/community/governance).
+[Governance document](/_pages/community/governance.md).
 
   </aside>
 


### PR DESCRIPTION
This plugin enables markdown links to refer the *source path*, instead of the URL of the rendered page. These paths are implicitly converted to the permalink paths, so the final result in the generated site is identical.

The result is that markdown links work on the source files directly, independently of Jekyll.

For example, when you view the preview of [`_pages/team.md` on GitHub](https://github.com/straight-shoota/crystal-website/blob/3d448c688b7a335800accf09f355f821f7f3f928/_pages/team.md), or [visit the generated *Team* page](https://deploy-preview-543--crystal-website.netlify.app/team/), clicking on the *Governance document* link, it takes you to the right place in both cases.

This is a tiny quality-of-life improvement, not critical but makes some things easier.