### PR TITLE
Tune link style

### DIFF
--- a/_sass/_utilities.scss
+++ b/_sass/_utilities.scss
@@ -15,6 +15,7 @@
     vertical-align: text-bottom;
   }
 
+  @extend .ui-link;
   --link-color: var(--light-text);
   --link-hover-color: var(--lighter-text);
 }
@@ -47,4 +48,10 @@ li {
   &.no {
     list-style-image: url("/assets/icons/close.svg");
   }
+}
+
+// This class marks a link as being part of the UI chrome, which disables some
+// visuals that are usually found on links. They're not underlined, for example.
+.ui-link {
+  --link-underline: none;
 }

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -31,8 +31,8 @@ $font-sizes: (
   --light-text: hsl(0, 0%, 27%);
   --lighter-text: var(--light-gray);
 
-  --link-color: hsl(199, 98%, 48%);
-  --link-hover-color: var(--link-color);
+  --link-color: currentColor;
+  --link-hover-color: var(--light-text);
 
   --header-color: var(--light-gray);
 

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -22,6 +22,7 @@ $font-sizes: (
   --tainted-white: hsl(0, 0%, 96%);
   --black: hsl(0, 0%, 3%);
   --light-gray: hsl(0, 0%, 47%);
+  --lighter-gray: hsl(0, 0%, 65%);
 
   --background-main: var(--white);
   --background-secondary: var(--tainted-white);

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -74,7 +74,8 @@ h6,
 :any-link {
   color: var(--link-color);
   text-underline-offset: 0.13em;
-  text-decoration: var(--link-underline, underline clamp(1.5px, 0.06em, 4px));
+  text-decoration: var(--link-underline, underline clamp(1.8px, 0.06em, 4px));
+  text-decoration-color: var(--lighter-gray);
   cursor: pointer;
 
   &:hover {

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -73,8 +73,8 @@ h6,
 
 :any-link {
   color: var(--link-color);
-  text-underline-offset: 0.15em;
-  text-decoration: none;
+  text-underline-offset: 0.13em;
+  text-decoration: var(--link-underline, underline clamp(1.5px, 0.06em, 4px));
   cursor: pointer;
 
   &:hover {

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -80,6 +80,19 @@ h6,
 
   &:hover {
     color: var(--link-hover-color);
+    text-decoration-color: var(--light-gray);
+  }
+
+  &:focus {
+    outline: 0.04em dotted var(--lighter-gray);
+  }
+}
+
+:any-link,
+summary {
+  &:focus {
+    outline: 0.14rem dotted var(--lighter-gray);
+    outline-offset: 0.08em;
   }
 }
 

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -126,7 +126,6 @@ kbd {
 strong,
 b {
   font-weight: 500;
-  color: var(--light-text);
 }
 
 blockquote {

--- a/_sass/components/_card.scss
+++ b/_sass/components/_card.scss
@@ -33,6 +33,8 @@
   }
 
   > .name {
+    @extend .ui-link;
+
     font-weight: 500;
     font-size: 112.5%;
     &:not(:last-child) {

--- a/_sass/components/_link-item.scss
+++ b/_sass/components/_link-item.scss
@@ -19,14 +19,8 @@
   @extend .icon-prefix;
   margin-inline-start: 0;
 
-  a {
-    color: var(--light-text);
-    &:not(.link-item__main) {
-      color: var(--lighter-text);
-    }
-  }
-
   .link-item__main {
+    --link-color: var(--light-text);
     font-weight: 500;
 
     > em {

--- a/_sass/components/_link-item.scss
+++ b/_sass/components/_link-item.scss
@@ -22,7 +22,6 @@
   a {
     color: var(--light-text);
     &:not(.link-item__main) {
-      text-decoration: underline;
       color: var(--lighter-text);
     }
   }

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -1,4 +1,5 @@
 body > header {
+  @extend .ui-link;
   --link-color: var(--light-text);
   --link-hover-color: var(--primary-text);
 

--- a/_sass/elements/_hex.scss
+++ b/_sass/elements/_hex.scss
@@ -4,6 +4,8 @@
 }
 
 .hex {
+  @extend .ui-link;
+
   --hex-height: 2.5em;
   --hex-width: 2px;
   --cos-a: var(--cos-70);
@@ -81,7 +83,7 @@
       var(--b) var(--hex-width)
     );
   }
-  
+
   &:is(a) {
     &:hover::before {
       background-color: hsl(0, 0%, 95%);

--- a/_sass/pages/_blog.scss
+++ b/_sass/pages/_blog.scss
@@ -27,6 +27,10 @@
     // With sufficient screen widht, author images move into the left gutter
     margin-inline-start: -4.5em;
   }
+
+  .post-title {
+    --link-underline: none;
+  }
 }
 
 .more-posts {

--- a/_sass/utilities/_footnote.scss
+++ b/_sass/utilities/_footnote.scss
@@ -6,8 +6,9 @@
 .reversefootnote {
   @extend .ui-link;
 
-  font-size: 0.61rem;
+  font-size: 0.7rem;
   font-weight: 600;
+  color: var(--lighter-text);
 }
 
 sup[role="doc-noteref"] {

--- a/_sass/utilities/_footnote.scss
+++ b/_sass/utilities/_footnote.scss
@@ -4,14 +4,10 @@
 
 [rel="footnote"],
 .reversefootnote {
+  @extend .ui-link;
+
   font-size: 0.61rem;
   font-weight: 600;
-  text-decoration: none;
-
-  &:hover,
-  &:active {
-    text-decoration: underline;
-  }
 }
 
 sup[role="doc-noteref"] {


### PR DESCRIPTION
Link styling has historically been quite confusing with different styles in different places. The current designs also show different style: sometimes underlined black text, sometimes non-underlined light blue. The relaunch branch had followed this. But it's time to standardize on a unique link styling.

Links have the current color and an underline serves as indicator.

This removes the shrill light blue link color which leads to calmer visuals and a smoother reading experience.

Before:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/2bea7910-9e8b-412d-b537-a1de8c5bf417)

After:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/355d13a1-54ab-4849-9fb6-9b8e8151816e)
