### PR TITLE
Add arch/targets to install page

### DIFF
--- a/_pages/install.md
+++ b/_pages/install.md
@@ -18,12 +18,18 @@ repository.
     <div class="install-entries">
       <div class="install-entry">
         <span class="title"><a href="on_linux#installer" title="Instructions for Linux installer">Installer (DEB &amp; RPM)</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         {% highlight shell %}curl -fsSL https://crystal-lang.org/install.sh | sudo bash{% endhighlight %}
         <a href="https://build.opensuse.org/project/show/devel:languages:crystal" title="Crystal repository on OBS" class="info">{% include icons/info.svg %}</a>
         <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge"></span>
       </div>
       <div class="install-entry">
         <span class="title"><a href="from_targz/">Tarball</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         <p>
           Archive in <a href="https://github.com/crystal-lang/crystal/releases">the latest release</a>.
         </p>
@@ -36,24 +42,37 @@ repository.
     <div class="install-entries">
       <div class="install-entry">
         <span class="title">APT (Debian, Ubuntu, etc.)</span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         {% highlight shell %}apt install crystal{% endhighlight %}
-        <a href="https://packages.debian.org/sid/source/crystal" title="Crystal package in Debian sid/unstable" class="info">{% include icons/info.svg %}</a>
+        <a href="https://packages.debian.org/sid/crystal" title="Crystal package in Debian sid/unstable" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="debian_unstable/crystal-lang" %}
       </div>
       <div class="install-entry">
         <span class="title">Apk (Alpine Linux)</span>
+        <span class="targets">
+          <code>x86_64</code>
+          <code>aarch64</code>
+        </span>
         {% highlight shell %}apk add crystal shards{% endhighlight %}
         <a href="https://pkgs.alpinelinux.org/packages?name=crystal" title="Crystal package on Alpine Linux package index" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="alpine_edge/crystal-lang" %}
       </div>
       <div class="install-entry">
         <span class="title">Pacman (Arch Linux)</span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         {% highlight shell %}pacman -S crystal shards{% endhighlight %}
         <a href="https://archlinux.org/packages/extra/x86_64/crystal/" title="Crystal package on Arch Linux package index" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="arch/crystal-lang" %}
       </div>
       <div class="install-entry">
         <span class="title"><a href="on_gentoo_linux/">Emerge (Gentoo)</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         {% highlight shell %}emerge -a dev-lang/crystal{% endhighlight %}
         <a href="https://packages.gentoo.org/packages/dev-lang/crystal" title="Crystal package on Gentoo package index" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="gentoo/crystal-lang" %}
@@ -65,6 +84,9 @@ repository.
     <div class="install-entries">
       <div class="install-entry">
         <span class="title">Homebrew/<wbr />Linuxbrew</span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         {% highlight shell %}brew install crystal{% endhighlight %}
         <a href="https://formulae.brew.sh/formula/crystal" title="Crystal package on Homebrew" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="homebrew/crystal-lang" %}
@@ -72,25 +94,39 @@ repository.
       </div>
       <div class="install-entry">
         <span class="title"><a href="from_asdf">asdf</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         {% highlight shell %}asdf plugin add crystal
 asdf install crystal latest{% endhighlight %}
         <a href="https://github.com/asdf-community/asdf-crystal" title="Crystal plugin for ASDF on GitHub" class="info">{% include icons/info.svg %}</a>
       </div>
       <div class="install-entry">
         <span class="title"><a href="from_snapcraft/">Snapcraft</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         {% highlight shell %}snap install crystal --classic{% endhighlight %}
         <a href="https://snapcraft.io/crystal" title="Crystal on Snapcraft" class="info">{% include icons/info.svg %}</a>
       </div>
       <div class="install-entry">
         <span class="title">Nix</span>
+        <span class="targets">
+          <code>x86_64</code>
+          <code>aarch64</code>
+        </span>
         <p><code>crystal</code> package.</p>
         <a href="https://search.nixos.org/packages?show=crystal&channel=unstable&from=0&size=50&sort=relevance&type=packages&query=crystal" title="Crystal on Nix package search" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="nix_unstable/crystal-lang" %}
       </div>
       <div class="install-entry">
         <a class="title" href="https://packagecloud.io/84codes/crystal">84codes (DEB &amp; RPM)</a>
+        <span class="targets">
+          <code>x86_64</code>
+          <code>aarch64</code>
+        </span>
         <a href="https://packagecloud.io/84codes/crystal" title="84codes' Crystal package on packagecloud.io" class="info">{% include icons/info.svg %}</a>
-        <p>Packages for amd64 and arm64</p>
+        <p></p>
       </div>
     </div>
   </div>
@@ -104,6 +140,9 @@ asdf install crystal latest{% endhighlight %}
     <div class="install-entries">
       <div class="install-entry">
         <span class="title"><a href="from_targz/">Tarball</a></span>
+        <span class="targets">
+          <code>universal</code>
+        </span>
         <p>Archive in the <a href="https://github.com/crystal-lang/crystal/releases">the latest release</a>.</p>
         <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge"></span>
       </div>
@@ -114,24 +153,39 @@ asdf install crystal latest{% endhighlight %}
     <div class="install-entries">
       <div class="install-entry">
       <span class="title">Homebrew</span>
+        <span class="targets">
+          <code>x86_64</code>
+          <code>aarch64</code>
+        </span>
         {% highlight shell %}brew install crystal{% endhighlight %}
         <a href="https://formulae.brew.sh/formula/crystal" title="Crystal package on Homebrew" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="homebrew/crystal-lang" %}
       </div>
       <div class="install-entry">
       <span class="title"><a href="from_asdf">asdf</a></span>
+        <span class="targets">
+          <code>universal</code>
+        </span>
         {% highlight shell %}asdf plugin add crystal
 asdf install crystal latest{% endhighlight %}
         <a href="https://github.com/asdf-community/asdf-crystal" title="Crystal plugin for ASDF on GitHub" class="info">{% include icons/info.svg %}</a>
       </div>
       <div class="install-entry">
       <span class="title">Nix</span>
+        <span class="targets">
+          <code>x86_64</code>
+          <code>aarch64</code>
+        </span>
         <p><code>crystal</code> package.</p>
         <a href="https://search.nixos.org/packages?show=crystal&channel=unstable&from=0&size=50&sort=relevance&type=packages&query=crystal" title="Crystal on Nix package search" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="nix_unstable/crystal-lang" %}
       </div>
       <div class="install-entry">
       <span class="title">MacPorts</span>
+        <span class="targets">
+          <code>x86_64</code>
+          <code>aarch64</code>
+        </span>
         {% highlight shell %}port install crystal{% endhighlight %}
         <a href="https://ports.macports.org/port/crystal/summary/" title="Crystal port on MacPorts package index" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="macports/crystal-lang" %}
@@ -152,6 +206,9 @@ Windows support is currently a preview and <a href="https://github.com/crystal-l
     <div class="install-entries">
       <div class="install-entry">
         <span class="title"><a href="on_windows">Installer</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         <p>
           Installer (<code>.exe</code>) in <a href="https://github.com/crystal-lang/crystal/releases">the latest release</a>.
         </p>
@@ -159,6 +216,9 @@ Windows support is currently a preview and <a href="https://github.com/crystal-l
       </div>
       <div class="install-entry">
         <span class="title"><a href="on_windows">Portable Archive</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         <p>
           Archive (<code>.zip</code>) in <a href="https://github.com/crystal-lang/crystal/releases">the latest release</a>.
         </p>
@@ -171,6 +231,9 @@ Windows support is currently a preview and <a href="https://github.com/crystal-l
     <div class="install-entries">
       <div class="install-entry">
         <span class="title"><a href="from_scoop">Scoop</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         {% highlight powershell %}scoop install git
 scoop bucket add crystal-preview https://github.com/neatorobito/scoop-crystal
 scoop install vs_2022_cpp_build_tools crystal{% endhighlight %}
@@ -178,6 +241,9 @@ scoop install vs_2022_cpp_build_tools crystal{% endhighlight %}
       </div>
       <div class="install-entry">
         <span class="title">WinGet</span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         <a href="https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/CrystalLang/Crystal/" title="Crystal manifest in WinGet packages repository" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="winget/crystal-lang" %}
       </div>
@@ -193,10 +259,18 @@ scoop install vs_2022_cpp_build_tools crystal{% endhighlight %}
     <div class="install-entries">
       <div class="install-entry">
         <span class="title"><a href="on_freebsd/#install-package">Package</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+          <code>aarch64</code>
+        </span>
         {% highlight shell %}sudo pkg install -y crystal shards{% endhighlight %}
       </div>
       <div class="install-entry">
         <span class="title"><a href="on_freebsd/#install-port">Port</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+          <code>aarch64</code>
+        </span>
         {% highlight shell %}sudo make -C/usr/ports/lang/crystal reinstall clean
 sudo make -C/usr/ports/devel/shards reinstall clean{% endhighlight %}
         <a href="https://www.freshports.org/lang/crystal" title="Crystal port on Freshports.org" class="info">{% include icons/info.svg %}</a>
@@ -214,10 +288,17 @@ sudo make -C/usr/ports/devel/shards reinstall clean{% endhighlight %}
     <div class="install-entries">
       <div class="install-entry">
         <span class="title"><a href="on_openbsd/#install-package">Package</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         {% highlight shell %}doas pkg_add crystal{% endhighlight %}
       </div>
       <div class="install-entry">
         <span class="title"><a href="on_openbsd/#install-port">Port</a></span>
+        <span class="targets">
+          <code>x86_64</code>
+          <code>aarch64</code>
+        </span>
         {% highlight shell %}doas make -C/usr/ports/lang/crystal clean install{% endhighlight %}
         <a href="https://openports.pl/path/lang/crystal" title="Crystal port on openports.pl" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="openbsd/crystal-lang" %}
@@ -234,6 +315,9 @@ sudo make -C/usr/ports/devel/shards reinstall clean{% endhighlight %}
     <div class="install-entries">
       <div class="install-entry">
         <span class="title"><a href="on_termux/">Termux</a></span>
+        <span class="targets">
+          <code>aarch64</code>
+        </span>
         {% highlight shell %}pkg install crystal{% endhighlight %}
         <a href="https://github.com/termux/termux-packages/tree/master/packages/crystal" title="Crystal package manifest in the Termux package repository on GitHub" class="info">{% include icons/info.svg %}</a>
         {% include elements/repology_badge.html repo="termux/crystal-lang" %}
@@ -249,7 +333,10 @@ sudo make -C/usr/ports/devel/shards reinstall clean{% endhighlight %}
     <h3>Crystal</h3>
     <div class="install-entries">
       <div class="install-entry">
-        <span class="title">crystallang (x86_64)</span>
+        <span class="title">crystallang</span>
+        <span class="targets">
+          <code>x86_64</code>
+        </span>
         {% highlight shell %}docker pull crystallang/crystal{% endhighlight %}
         <a href="https://hub.docker.com/r/crystallang/crystal/" title="crystallang's Crystal image on Docker Hub" class="info">{% include icons/info.svg %}</a>
         <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge"></span>
@@ -260,7 +347,11 @@ sudo make -C/usr/ports/devel/shards reinstall clean{% endhighlight %}
     <h3>Community</h3>
     <div class="install-entries">
       <div class="install-entry">
-        <span class="title">84codes (x86_64 &amp; aarch64)</span>
+        <span class="title">84codes</span>
+        <span class="targets">
+          <code>x86_64</code>
+          <code>aarch64</code>
+        </span>
         {% highlight shell %}docker pull 84codes/crystal{% endhighlight %}
         <a href="https://hub.docker.com/r/84codes/crystal" title="84codes' Crystal image on Docker Hub" class="info">{% include icons/info.svg %}</a>
       </div>

--- a/_sass/pages/_install.scss
+++ b/_sass/pages/_install.scss
@@ -29,7 +29,8 @@
 .install-entry {
   display: grid;
   grid-template-columns: subgrid;
-  grid-template-areas: "title version command info";
+  grid-template-areas: "title version command info" "targets version command info";
+  grid-template-rows: auto 1fr;
   grid-column: 1 / -1;
   --link-color: var(--body-text);
   align-items: baseline;
@@ -40,6 +41,20 @@
   }
   > .title {
     grid-area: title;
+  }
+
+  > .targets {
+    font-size: 80%;
+    grid-area: targets;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--padding-sm) var(--padding-xs);
+
+    > code {
+      background: transparent;
+      padding: 0;
+      color: var(--lighter-text);
+    }
   }
 
   > p,
@@ -122,16 +137,20 @@ img.version-badge {
 }
 @media (max-width: 37em) {
   .install-panels {
-    grid-template-columns: [title] 1.8fr [version] 46px [info] 2.5ch [end];
+    grid-template-columns: [title] 1.8fr [targets] auto [version] 46px [info] 2.5ch [end];
     column-gap: var(--padding-sm);
   }
   .install-entry {
     row-gap: var(--padding-xs);
     padding-block: var(--padding-sm);
-    grid-template-areas: "title version info" "command command command";
+    grid-template-areas: "title targets version info" "command command command command";
 
     > p {
       padding: 0;
+    }
+
+    > .targets {
+      justify-content: end;
     }
   }
 }


### PR DESCRIPTION
This patch adds to the install page for which architecture packages are available.

![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/952bf0d6-c618-4087-bb17-d5613f0d49f9)
