### PR TITLE
Extract package data for install page

### DIFF
--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -1,0 +1,295 @@
+- type: crystal
+  os: Linux
+  arch: [x86_64]
+  title: Installer (DEB &amp; RPM)
+  label: Linux installer
+  instructions_href: on_linux#installer
+  example: |
+    ```shell
+    curl -fsSL https://crystal-lang.org/install.sh | sudo bash
+    ```
+  repo_href: https://build.opensuse.org/project/show/devel:languages:crystal
+  repo_description: Crystal repository on OBS
+  repology: crystal
+- type: crystal
+  os: Linux
+  arch: [x86_64]
+  title: Tarball
+  instructions_href: from_targz/
+  example: 'Archive in [the latest release](https://github.com/crystal-lang/crystal/releases).'
+  repology: crystal
+- type: system
+  os: Linux
+  arch: [x86_64]
+  title: APT (Debian, Ubuntu, etc.)
+  example: |
+    ```shell
+    apt install crystal
+    ```
+  repo_href: https://packages.debian.org/sid/crystal
+  repo_description: Crystal package in Debian sid/unstable
+  repology: debian_unstable/crystal-lang
+- type: system
+  os: Linux
+  arch: [x86_64, aarch64]
+  title: Apk (Alpine Linux)
+  example: |
+    ```shell
+    apk add crystal shards
+    ```
+  repo_href: https://pkgs.alpinelinux.org/packages?name=crystal
+  repo_description: Crystal package on Alpine Linux package index
+  repology: alpine_edge/crystal-lang
+- type: system
+  os: Linux
+  arch: [x86_64]
+  title: Pacman (Arch Linux)
+  example: |
+    ```shell
+    pacman -S crystal shards
+    ```
+  repo_href: https://archlinux.org/packages/extra/x86_64/crystal/
+  repo_description: Crystal package on Arch Linux package index
+  repology: arch/crystal-lang
+- type: system
+  os: Linux
+  arch: [x86_64]
+  title: Emerge (Gentoo)
+  instructions_href: on_gentoo_linux/
+  example: |
+    ```shell
+    emerge -a dev-lang/crystal
+    ```
+  repo_href: https://packages.gentoo.org/packages/dev-lang/crystal
+  repo_description: Crystal package on Gentoo package index
+  repology: gentoo/crystal-lang
+- type: community
+  os: Linux
+  arch: [x86_64]
+  title: Homebrew/Linuxbrew
+  example: |
+    ```shell
+    brew install crystal
+    ```
+  repo_href: https://formulae.brew.sh/formula/crystal
+  repo_description: Crystal package on Homebrew
+  repology: homebrew/crystal-lang
+  repology: crystal
+- type: community
+  os: Linux
+  arch: [x86_64]
+  title: asdf
+  instructions_href: from_asdf
+  example: |
+    ```shell
+    asdf plugin add crystal
+    asdf install crystal latest
+    ```
+  repo_href: https://github.com/asdf-community/asdf-crystal
+  repo_description: Crystal plugin for ASDF on GitHub
+- type: community
+  os: Linux
+  arch: [x86_64]
+  title: Snapcraft
+  instructions_href: from_snapcraft/
+  example: |
+    ```shell
+    snap install crystal --classic
+    ```
+  repo_href: https://snapcraft.io/crystal
+  repo_description: Crystal on Snapcraft
+- type: community
+  os: Linux
+  arch: [x86_64, aarch64]
+  title: Nix
+  example: '`crystal` package'
+  repo_href: https://search.nixos.org/packages?show=crystal&channel=unstable&from=0&size=50&sort=relevance&type=packages&query=crystal
+  repo_description: Crystal on Nix package search
+  repology: nix_unstable/crystal-lang
+- type: community
+  os: Linux
+  arch: [x86_64, aarch64]
+  title: 84codes (DEB &amp; RPM)
+  instructions_href: https://packagecloud.io/84codes/crystal
+  repo_href: https://packagecloud.io/84codes/crystal
+  repo_description: 84codes' Crystal package on packagecloud.io
+- type: crystal
+  os: MacOS
+  arch: [universal]
+  title: Tarball
+  instructions_href: from_targz/
+  example: 'Archive in the [the latest release](https://github.com/crystal-lang/crystal/releases).'
+  repology: crystal
+- type: community
+  os: MacOS
+  arch: [x86_64, aarch64]
+  title: Homebrew
+  example: |
+    ```shell
+    brew install crystal
+    ```
+  repo_href: https://formulae.brew.sh/formula/crystal
+  repo_description: Crystal package on Homebrew
+  repology: homebrew/crystal-lang
+- type: community
+  os: MacOS
+  arch: [universal]
+  title: asdf
+  instructions_href: from_asdf
+  example: |
+    ```shell
+    asdf plugin add crystal
+    asdf install crystal latest
+    ```
+  repo_href: https://github.com/asdf-community/asdf-crystal
+  repo_description: Crystal plugin for ASDF on GitHub
+- type: community
+  os: MacOS
+  arch: [x86_64, aarch64]
+  title: Nix
+  example: '`crystal` package'
+  repo_href: https://search.nixos.org/packages?show=crystal&channel=unstable&from=0&size=50&sort=relevance&type=packages&query=crystal
+  repo_description: Crystal on Nix package search
+  repology: nix_unstable/crystal-lang
+- type: community
+  os: MacOS
+  arch: [x86_64, aarch64]
+  title: MacPorts
+  example: |
+    ```shell
+    port install crystal
+    ```
+  repo_href: https://ports.macports.org/port/crystal/summary/
+  repo_description: Crystal port on MacPorts package index
+  repology: macports/crystal-lang
+- type: crystal
+  os: Windows
+  arch: [x86_64]
+  title: Installer
+  instructions_href: on_windows
+  example: Installer (`.exe`) in [the latest release](https://github.com/crystal-lang/crystal/releases).
+  repology: crystal
+- type: crystal
+  os: Windows
+  arch: [x86_64]
+  title: Portable Archive
+  instructions_href: on_windows
+  example: Archive (`.zip`) in [the latest release](https://github.com/crystal-lang/crystal/releases).
+  repology: crystal
+- type: community
+  os: Windows
+  arch: [x86_64]
+  title: Scoop
+  instructions_href: from_scoop
+  example: |
+    ```powershell
+    scoop install git
+    scoop bucket add crystal-preview https://github.com/neatorobito/scoop-crystal
+    scoop install vs_2022_cpp_build_tools crystal
+    ```
+  repo_href: https://github.com/neatorobito/scoop-crystal
+  repo_description: Scoop repository for Crystal on GitHub
+- type: community
+  os: Windows
+  arch: [x86_64]
+  title: WinGet
+  repo_href: https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/CrystalLang/Crystal/
+  repo_description: Crystal manifest in WinGet packages repository
+  repology: winget/crystal-lang
+- type: system
+  os: FreeBSD
+  arch: [x86_64, aarch64]
+  title: Package
+  instructions_href: on_freebsd/#install-package
+  example: |
+    ```shell
+    sudo pkg install -y crystal shards
+    ```
+- type: system
+  os: FreeBSD
+  arch: [x86_64, aarch64]
+  title: Port
+  instructions_href: on_freebsd/#install-port
+  example: |
+    ```shell
+    sudo make -C/usr/ports/lang/crystal reinstall clean
+    sudo make -C/usr/ports/devel/shards reinstall clean
+    ```
+  repo_href: https://www.freshports.org/lang/crystal
+  repo_description: Crystal port on Freshports.org
+  repology: freebsd/crystal-lang
+- type: system
+  os: OpenBSD
+  arch: [x86_64, aarch64]
+  title: Package
+  instructions_href: on_openbsd/#install-package
+  example: |
+    ```shell
+    doas pkg_add crystal
+    ```
+- type: system
+  os: OpenBSD
+  arch: [x86_64, aarch64]
+  title: Port
+  instructions_href: on_openbsd/#install-port
+  example: |
+    ```shell
+    doas make -C/usr/ports/lang/crystal clean install
+    ```
+  repo_href: https://openports.pl/path/lang/crystal
+  repo_description: Crystal port on openports.pl
+  repology: openbsd/crystal-lang
+- type: community
+  os: Android
+  arch: [aarch64]
+  title: Termux
+  instructions_href: on_termux/
+  example: |
+    ```shell
+    pkg install crystal
+    ```
+  repo_href: https://github.com/termux/termux-packages/tree/master/packages/crystal
+  repo_description: Crystal package manifest in the Termux package repository on GitHub
+  repology: termux/crystal-lang
+- type: crystal
+  os: Docker
+  arch: [x86_64]
+  title: crystallang
+  example: |
+    ```shell
+    docker pull crystallang/crystal
+    ```
+  repo_href: https://hub.docker.com/r/crystallang/crystal/
+  repo_description: crystallang's Crystal image on Docker Hub
+  repology: crystal
+- type: community
+  os: Docker
+  arch: [x86_64, aarch64]
+  title: 84codes
+  example: |
+    ```shell
+    docker pull 84codes/crystal
+    ```
+  repo_href: https://hub.docker.com/r/84codes/crystal
+  repo_description: 84codes' Crystal image on Docker Hub
+- type: crystal
+  os: Tools
+  arch: [x86_64, aarch64]
+  title: GitHub Actions
+  instructions_href: https://crystal-lang.github.io/install-crystal/
+  example: |
+    ```yaml
+    - uses: crystal-lang/install-crystal@v1
+    ```
+  repo_href: https://github.com/crystal-lang/install-crystal
+  repo_description: GitHub repo for `install-crystal` action
+- type: community
+  os: Tools
+  arch: [x86_64, aarch64]
+  title: devenv.sh
+  example: |
+    ```nix
+    languages.crystal.enable = true
+    ```
+  repo_href: https://devenv.sh/reference/options/#languagescrystalenable
+  repo_description: Devenv.sh reference for Crystal language

--- a/_includes/pages/install/group.html
+++ b/_includes/pages/install/group.html
@@ -1,0 +1,42 @@
+{% assign entries = site.data.packages | where: "os", include.os | where: "type", include.type %}
+{% assign size = entries | size %}
+{% assign latest_release = site.releases | reverse | first %}
+{% if size > 0 %}
+<div class="install-group">
+  <h3>{{ include.type | capitalize }}</h3>
+  <div class="install-entries">
+    {% for entry in entries %}
+      <div class="install-entry">
+        <span class="title">
+          {% if entry.instructions_href %}
+            <a href="{{ entry.instructions_href }}" title="Instructions for {{ entry.label | default: entry.title }}">
+          {% endif %}
+          {{ entry.title }}
+          {% if entry.instructions_href %}
+            </a>
+          {% endif %}
+        </span>
+        {% assign targets_size = entry.arch | size %}
+        {% if targets_size > 0 %}
+        <span class="targets">
+          {% for arch in entry.arch %}
+            <code>{{ arch }}</code>
+          {% endfor %}
+        </span>
+        {% endif %}
+        {% if entry.repology == "crystal" %}
+          <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge" alt="Latest version: {{ latest_release.version }}"></span>
+        {% elsif entry.repology %}
+          {% include elements/repology_badge.html repo=entry.repology %}
+        {% endif %}
+        <div class="example">
+          {{ entry.example | markdownify }}
+        </div>
+        {% if entry.repo_href %}
+          <a href="{{ entry.repo_href }}" title="{{ entry.repo_description }}" class="info">{% include icons/info.svg %}</a>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}

--- a/_includes/pages/install/section.html
+++ b/_includes/pages/install/section.html
@@ -1,0 +1,5 @@
+<div class="install-panels">
+  {% include pages/install/group.html os=include.os type="crystal" %}
+  {% include pages/install/group.html os=include.os type="system" %}
+  {% include pages/install/group.html os=include.os type="community" %}
+</div>

--- a/_pages/install.md
+++ b/_pages/install.md
@@ -12,187 +12,11 @@ more up to date.
 DEB and RPM packages of the most recent release are available in our own package
 repository.
 
-<div class="install-panels">
-  <div class="install-group">
-    <h3>Crystal</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title"><a href="on_linux#installer" title="Instructions for Linux installer">Installer (DEB &amp; RPM)</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        {% highlight shell %}curl -fsSL https://crystal-lang.org/install.sh | sudo bash{% endhighlight %}
-        <a href="https://build.opensuse.org/project/show/devel:languages:crystal" title="Crystal repository on OBS" class="info">{% include icons/info.svg %}</a>
-        <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge" alt=""></span>
-      </div>
-      <div class="install-entry">
-        <span class="title"><a href="from_targz/">Tarball</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        <p>
-          Archive in <a href="https://github.com/crystal-lang/crystal/releases">the latest release</a>.
-        </p>
-        <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge" alt=""></span>
-      </div>
-    </div>
-  </div>
-  <div class="install-group">
-    <h3>System</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title">APT (Debian, Ubuntu, etc.)</span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        {% highlight shell %}apt install crystal{% endhighlight %}
-        <a href="https://packages.debian.org/sid/crystal" title="Crystal package in Debian sid/unstable" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="debian_unstable/crystal-lang" %}
-      </div>
-      <div class="install-entry">
-        <span class="title">Apk (Alpine Linux)</span>
-        <span class="targets">
-          <code>x86_64</code>
-          <code>aarch64</code>
-        </span>
-        {% highlight shell %}apk add crystal shards{% endhighlight %}
-        <a href="https://pkgs.alpinelinux.org/packages?name=crystal" title="Crystal package on Alpine Linux package index" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="alpine_edge/crystal-lang" %}
-      </div>
-      <div class="install-entry">
-        <span class="title">Pacman (Arch Linux)</span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        {% highlight shell %}pacman -S crystal shards{% endhighlight %}
-        <a href="https://archlinux.org/packages/extra/x86_64/crystal/" title="Crystal package on Arch Linux package index" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="arch/crystal-lang" %}
-      </div>
-      <div class="install-entry">
-        <span class="title"><a href="on_gentoo_linux/">Emerge (Gentoo)</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        {% highlight shell %}emerge -a dev-lang/crystal{% endhighlight %}
-        <a href="https://packages.gentoo.org/packages/dev-lang/crystal" title="Crystal package on Gentoo package index" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="gentoo/crystal-lang" %}
-      </div>
-    </div>
-  </div>
-  <div class="install-group">
-    <h3>Community</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title">Homebrew/<wbr />Linuxbrew</span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        {% highlight shell %}brew install crystal{% endhighlight %}
-        <a href="https://formulae.brew.sh/formula/crystal" title="Crystal package on Homebrew" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="homebrew/crystal-lang" %}
-        <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge" alt=""></span>
-      </div>
-      <div class="install-entry">
-        <span class="title"><a href="from_asdf">asdf</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        {% highlight shell %}asdf plugin add crystal
-asdf install crystal latest{% endhighlight %}
-        <a href="https://github.com/asdf-community/asdf-crystal" title="Crystal plugin for ASDF on GitHub" class="info">{% include icons/info.svg %}</a>
-      </div>
-      <div class="install-entry">
-        <span class="title"><a href="from_snapcraft/">Snapcraft</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        {% highlight shell %}snap install crystal --classic{% endhighlight %}
-        <a href="https://snapcraft.io/crystal" title="Crystal on Snapcraft" class="info">{% include icons/info.svg %}</a>
-      </div>
-      <div class="install-entry">
-        <span class="title">Nix</span>
-        <span class="targets">
-          <code>x86_64</code>
-          <code>aarch64</code>
-        </span>
-        <p><code>crystal</code> package.</p>
-        <a href="https://search.nixos.org/packages?show=crystal&channel=unstable&from=0&size=50&sort=relevance&type=packages&query=crystal" title="Crystal on Nix package search" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="nix_unstable/crystal-lang" %}
-      </div>
-      <div class="install-entry">
-        <a class="title" href="https://packagecloud.io/84codes/crystal">84codes (DEB &amp; RPM)</a>
-        <span class="targets">
-          <code>x86_64</code>
-          <code>aarch64</code>
-        </span>
-        <a href="https://packagecloud.io/84codes/crystal" title="84codes' Crystal package on packagecloud.io" class="info">{% include icons/info.svg %}</a>
-        <p></p>
-      </div>
-    </div>
-  </div>
-</div>
+{% include pages/install/section.html os="Linux" %}
 
 ## MacOS
 
-<div class="install-panels">
-  <div class="install-group">
-    <h3>Crystal</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title"><a href="from_targz/">Tarball</a></span>
-        <span class="targets">
-          <code>universal</code>
-        </span>
-        <p>Archive in the <a href="https://github.com/crystal-lang/crystal/releases">the latest release</a>.</p>
-        <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge" alt=""></span>
-      </div>
-    </div>
-  </div>
-  <div class="install-group">
-    <h3>Community</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-      <span class="title">Homebrew</span>
-        <span class="targets">
-          <code>x86_64</code>
-          <code>aarch64</code>
-        </span>
-        {% highlight shell %}brew install crystal{% endhighlight %}
-        <a href="https://formulae.brew.sh/formula/crystal" title="Crystal package on Homebrew" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="homebrew/crystal-lang" %}
-      </div>
-      <div class="install-entry">
-      <span class="title"><a href="from_asdf">asdf</a></span>
-        <span class="targets">
-          <code>universal</code>
-        </span>
-        {% highlight shell %}asdf plugin add crystal
-asdf install crystal latest{% endhighlight %}
-        <a href="https://github.com/asdf-community/asdf-crystal" title="Crystal plugin for ASDF on GitHub" class="info">{% include icons/info.svg %}</a>
-      </div>
-      <div class="install-entry">
-      <span class="title">Nix</span>
-        <span class="targets">
-          <code>x86_64</code>
-          <code>aarch64</code>
-        </span>
-        <p><code>crystal</code> package.</p>
-        <a href="https://search.nixos.org/packages?show=crystal&channel=unstable&from=0&size=50&sort=relevance&type=packages&query=crystal" title="Crystal on Nix package search" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="nix_unstable/crystal-lang" %}
-      </div>
-      <div class="install-entry">
-      <span class="title">MacPorts</span>
-        <span class="targets">
-          <code>x86_64</code>
-          <code>aarch64</code>
-        </span>
-        {% highlight shell %}port install crystal{% endhighlight %}
-        <a href="https://ports.macports.org/port/crystal/summary/" title="Crystal port on MacPorts package index" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="macports/crystal-lang" %}
-      </div>
-    </div>
-  </div>
-</div>
+{% include pages/install/section.html os="MacOS" %}
 
 <a id="windows"></a>
 
@@ -200,189 +24,27 @@ asdf install crystal latest{% endhighlight %}
 
 Windows support is currently a preview and <a href="https://github.com/crystal-lang/crystal/issues/5430">not yet complete</a>.
 
-<div class="install-panels">
-  <div class="install-group">
-  <h3>Crystal</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title"><a href="on_windows">Installer</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        <p>
-          Installer (<code>.exe</code>) in <a href="https://github.com/crystal-lang/crystal/releases">the latest release</a>.
-        </p>
-        <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge" alt=""></span>
-      </div>
-      <div class="install-entry">
-        <span class="title"><a href="on_windows">Portable Archive</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        <p>
-          Archive (<code>.zip</code>) in <a href="https://github.com/crystal-lang/crystal/releases">the latest release</a>.
-        </p>
-        <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge" alt=""></span>
-      </div>
-    </div>
-  </div>
-  <div class="install-group">
-    <h3>Community</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title"><a href="from_scoop">Scoop</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        {% highlight powershell %}scoop install git
-scoop bucket add crystal-preview https://github.com/neatorobito/scoop-crystal
-scoop install vs_2022_cpp_build_tools crystal{% endhighlight %}
-        <a href="https://github.com/neatorobito/scoop-crystal" title="Scoop repository for Crystal on GitHub" class="info">{% include icons/info.svg %}</a>
-      </div>
-      <div class="install-entry">
-        <span class="title">WinGet</span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        <a href="https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/CrystalLang/Crystal/" title="Crystal manifest in WinGet packages repository" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="winget/crystal-lang" %}
-      </div>
-    </div>
-  </div>
-</div>
+{% include pages/install/section.html os="Windows" %}
 
 ## FreeBSD
 
-<div class="install-panels">
-  <div class="install-group">
-    <h3>System</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title"><a href="on_freebsd/#install-package">Package</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-          <code>aarch64</code>
-        </span>
-        {% highlight shell %}sudo pkg install -y crystal shards{% endhighlight %}
-      </div>
-      <div class="install-entry">
-        <span class="title"><a href="on_freebsd/#install-port">Port</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-          <code>aarch64</code>
-        </span>
-        {% highlight shell %}sudo make -C/usr/ports/lang/crystal reinstall clean
-sudo make -C/usr/ports/devel/shards reinstall clean{% endhighlight %}
-        <a href="https://www.freshports.org/lang/crystal" title="Crystal port on Freshports.org" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="freebsd/crystal-lang" %}
-      </div>
-    </div>
-  </div>
-</div>
+{% include pages/install/section.html os="FreeBSD" %}
 
 ## OpenBSD
 
-<div class="install-panels">
-  <div class="install-group">
-    <h3>System</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title"><a href="on_openbsd/#install-package">Package</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        {% highlight shell %}doas pkg_add crystal{% endhighlight %}
-      </div>
-      <div class="install-entry">
-        <span class="title"><a href="on_openbsd/#install-port">Port</a></span>
-        <span class="targets">
-          <code>x86_64</code>
-          <code>aarch64</code>
-        </span>
-        {% highlight shell %}doas make -C/usr/ports/lang/crystal clean install{% endhighlight %}
-        <a href="https://openports.pl/path/lang/crystal" title="Crystal port on openports.pl" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="openbsd/crystal-lang" %}
-      </div>
-    </div>
-  </div>
-</div>
+{% include pages/install/section.html os="OpenBSD" %}
 
 ## Android
 
-<div class="install-panels">
-  <div class="install-group">
-    <h3>Community</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title"><a href="on_termux/">Termux</a></span>
-        <span class="targets">
-          <code>aarch64</code>
-        </span>
-        {% highlight shell %}pkg install crystal{% endhighlight %}
-        <a href="https://github.com/termux/termux-packages/tree/master/packages/crystal" title="Crystal package manifest in the Termux package repository on GitHub" class="info">{% include icons/info.svg %}</a>
-        {% include elements/repology_badge.html repo="termux/crystal-lang" %}
-      </div>
-    </div>
-  </div>
-</div>
+{% include pages/install/section.html os="Android" %}
 
 ## Docker
 
-<div class="install-panels">
-  <div class="install-group">
-    <h3>Crystal</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title">crystallang</span>
-        <span class="targets">
-          <code>x86_64</code>
-        </span>
-        {% highlight shell %}docker pull crystallang/crystal{% endhighlight %}
-        <a href="https://hub.docker.com/r/crystallang/crystal/" title="crystallang's Crystal image on Docker Hub" class="info">{% include icons/info.svg %}</a>
-        <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge" alt=""></span>
-      </div>
-    </div>
-  </div>
-  <div class="install-group">
-    <h3>Community</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title">84codes</span>
-        <span class="targets">
-          <code>x86_64</code>
-          <code>aarch64</code>
-        </span>
-        {% highlight shell %}docker pull 84codes/crystal{% endhighlight %}
-        <a href="https://hub.docker.com/r/84codes/crystal" title="84codes' Crystal image on Docker Hub" class="info">{% include icons/info.svg %}</a>
-      </div>
-    </div>
-  </div>
-</div>
+{% include pages/install/section.html os="Docker" %}
 
 ## Developer Tools
 
-<div class="install-panels">
-  <div class="install-group">
-    <h3>Crystal</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title"><a href="https://crystal-lang.github.io/install-crystal/">GitHub Actions</a></span>
-        {% highlight yaml %}- uses: crystal-lang/install-crystal@v1{% endhighlight %}
-        <a href="https://github.com/crystal-lang/install-crystal" class="info" title="GitHub repo for `install-crystal` action">{% include icons/info.svg %}</a>
-      </div>
-    </div>
-  </div>
-  <div class="install-group">
-    <h3>Community</h3>
-    <div class="install-entries">
-      <div class="install-entry">
-        <span class="title">devenv.sh</span>
-        {% highlight nix %}languages.crystal.enable = true{% endhighlight %}
-        <a href="https://devenv.sh/reference/options/#languagescrystalenable" class="info" title="Devenv.sh reference for Crystal language">{% include icons/info.svg %}</a>
-      </div>
-    </div>
-  </div>
-</div>
+{% include pages/install/section.html os="Tools" %}
 
 ## Nightly builds
 

--- a/_sass/pages/_install.scss
+++ b/_sass/pages/_install.scss
@@ -57,19 +57,19 @@
     }
   }
 
-  > p,
-  > .highlight {
+  > .example {
     grid-area: command;
     margin-left: 0 var(--padding-xs);
-  }
 
-  > .highlight {
-    > pre {
-      padding: var(--padding-xs);
+    .highlight {
+      > pre {
+        padding: var(--padding-xs);
+      }
     }
-  }
-  > p {
-    padding: calc(var(--padding-xs) * 0.6);
+
+    > p {
+      padding: calc(var(--padding-xs) * 0.6);
+    }
   }
 
   > .repo-badge {


### PR DESCRIPTION
Extract all the package information from a big HTML blob into structured data and a template to render that.
This is overall more succinct and easier to work with. Data and presentation are separated. It also makes it possible to re-use some of the information in other place (for example in the install sub pages).

Should've probably done this a long time ago.

Alternatively we could use a new custom collection for package data. Would be pretty much the same result except that the content of packages.yml` is spread across individual files for each entry. But I think it's a bit easier to manage in a single data file.

The generated HTML changes slightly because we're now using standard markdown code blocks instead of `{% highlight %}` tags. This required some adjustments in the styles. There are (supposed to be) no visual changes however.