### PR TITLE
Refactor sponsors table

### DIFF
--- a/_includes/pages/sponsors/table.html
+++ b/_includes/pages/sponsors/table.html
@@ -1,7 +1,6 @@
 <table class="table" id="sponsors-tbl">
   <thead>
-    <th aria-label="Sponsor logo"></th>
-    <th><span>Supporter</span></th>
+    <th class="name"><span>Supporter</span></th>
     <th class="currency" data-sort-method="number" aria-sort="descending"><span>This month</span></th>
     <th class="currency" data-sort-method="number"><span>All time</span></th>
     <th class="since" data-sort-method="date"><span>Since</span></th>
@@ -10,30 +9,16 @@
     {% for sp in site.data.sponsors %}
       {% capture sponsor_class %}level-{{sp.level}} sponsor{% endcapture %}
       <tr class="{{sponsor_class}}">
-        <td class="col-logo">
-          {% if sp.logo %}
-            {% if sp.url %}
-              <a href="{{sp.url}}" rel="sponsored nofollow">
-                <img src="/assets/{{ sp.logo }}" alt="" />
-              </a>
-            {% else %}
-              <span>
-                <img src="/assets/{{ sp.logo }}" alt="" />
-              </span>
-            {% endif %}
-          {% else %}
-            &nbsp;
-          {% endif %}
-        </td>
         <th class="name" scope="row">
           {% if sp.url %}
             <a href="{{sp.url}}" rel="sponsored nofollow">
-              {{sp.name}}
+          {% endif %}
+              {% if sp.logo %}
+                <img src="/assets/{{ sp.logo }}" alt="" />
+              {% endif %}
+              <span>{{sp.name}}</span>
+          {% if sp.url %}
             </a>
-          {% else %}
-            <span>
-              {{sp.name}}
-            </span>
           {% endif %}
         </th>
         <td class="currency">

--- a/_sass/pages/_sponsors.scss
+++ b/_sass/pages/_sponsors.scss
@@ -10,14 +10,34 @@
       white-space: nowrap;
     }
 
-    &.name,
-    &.col-logo {
+    &.name {
+      display: grid;
       padding: 0;
-      font-weight: 400;
+      grid-template-columns: calc(2em + var(--padding-sm)) 1fr;
+      grid-gap: var(--padding-sm);
+      align-items: center;
+
+      &[scope="row"] {
+        font-weight: unset;
+      }
 
       > * {
-        display: block;
-        padding: 0.75em 0.9em;
+        padding-block: var(--padding-sm);
+      }
+
+      > a {
+        display: grid;
+        grid-template-columns: subgrid;
+        grid-column: 1/-1;
+        align-items: center;
+      }
+
+      img {
+        justify-self: end;
+      }
+
+      span {
+        grid-column-start: 2;
       }
     }
   }


### PR DESCRIPTION
Refactor the layout of the sponsors table. It previously had the sponsor logo and text in different columns. They're now combined in one column and form a single link (instead of two separate ones).

There are little visual changes, except for a tiny whitespace adjustment as a side-effect.
The link now spans across both image and text, indicated by the focus outline in these screenshots:

Before:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/f2db9a44-062b-44f3-be44-e9c25c637587)

After:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/e8ba8361-c42b-4fd1-a852-abb509a7fd3a)

