### PR TITLE
Increase whitespace between blockflow sections

### DIFF
--- a/_sass/mixins/_blockflow.scss
+++ b/_sass/mixins/_blockflow.scss
@@ -18,4 +18,8 @@
   :where(& > :is(h1, h2, h3, h4) + *) {
     margin-block-start: var(--block-flow-xs);
   }
+
+  :where(& > section + section) {
+    margin-block-start: var(--block-flow-lg);
+  }
 }


### PR DESCRIPTION
I think this had been in the initial implementation, but got lost somewhere down the road.

Before:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/56be1d5a-6cda-46a1-ad18-fdacfdae8d18)


After:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/04a50e60-85a2-40e5-aba3-4f2714213188)
