### PR TITLE
Tune typography

### DIFF
--- a/_pages/blog.html
+++ b/_pages/blog.html
@@ -12,7 +12,7 @@ section: blog
 
     {% include posts/meta.html post=post %}
 
-    <div class="excerpt">{{ post.summary | default: post.excerpt }}</div>
+    <div class="excerpt">{{ post.summary | default: post.excerpt | markdownify }}</div>
   </div>
   {% endfor %}
 </div>

--- a/_sass/components/_card.scss
+++ b/_sass/components/_card.scss
@@ -11,6 +11,7 @@
   font-size: 80%;
   position: relative;
   line-height: var(--line-height-sm);
+  text-wrap: balance;
 
   --card-padding: var(--padding-sm);
 

--- a/_sass/components/_post-teaser.scss
+++ b/_sass/components/_post-teaser.scss
@@ -81,6 +81,8 @@
   margin-right: auto;
   margin-left: -0.1ch;
 
+  text-wrap: balance;
+
   &:is(h1) {
     font-size: 300%;
   }

--- a/_sass/elements/_link-item.scss
+++ b/_sass/elements/_link-item.scss
@@ -1,8 +1,7 @@
 .link-items {
   > h3 {
-    font-size: 1em;
     font-weight: 200;
-    margin-bottom: var(--padding-xs);
+    margin-bottom: var(--padding-sm);
   }
 
   .link-item + .link-item {

--- a/_sass/elements/_link-item.scss
+++ b/_sass/elements/_link-item.scss
@@ -14,7 +14,7 @@
   margin-inline-start: 0;
 
   .link-item__main {
-    --link-color: var(--light-text);
+    --link-color: var(--primary-text);
     font-weight: 500;
 
     > em {

--- a/_sass/mixins/_blockflow.scss
+++ b/_sass/mixins/_blockflow.scss
@@ -22,4 +22,8 @@
   :where(& > section + section) {
     margin-block-start: var(--block-flow-lg);
   }
+
+  :where(& > p + p) {
+    margin-block-start: var(--block-flow-xs);
+  }
 }


### PR DESCRIPTION
Several tiny detail improvements.

For example `text-wrap: balance`

| Before | After |
|---------|-------|
| ![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/30f8a77d-d573-432b-9614-b2f157815f0e) | ![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/4d18c81d-5656-4295-9382-cc6d17c46c8d)

