### PR TITLE
Replace disqus comment thread plugin with link to archive

### DIFF
--- a/_includes/posts/blog_row.html
+++ b/_includes/posts/blog_row.html
@@ -15,10 +15,6 @@
       <h3 class="title">{{ include.post.title }}</h3>
       <p class="summary">{{ include.post.summary }}</p>
     </a>
-    <p>
-      <i class="material-icons">chat_bubble_outline</i>
-      <span class="disqus-comment-count" data-disqus-identifier="{{include.post.id}}"></span>
-    </p>
     <hr class="squares" />
   </div>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -30,34 +30,14 @@ layout: base
       <div class="col m1"></div>
     </div>
 
-    <div class="row disqus">
-      <div class="col m2"></div>
-      <div class="col s12 m9" id='disqus_thread'>
-        {{ content }}
+    {% if page.comment_href %}
+      <div class="row disqus">
+        <div class="col m2"></div>
+        <div class="col s12 m9">
+          <a href="{{ page.comment_href }}" class="btn btn-flat">Comment archive for this post</a>
+        </div>
+        <div class="col m1"></div>
       </div>
-      <div class="col m1"></div>
-    </div>
+    {% endif %}
   </div>
-  <script>
-    /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-    var disqus_shortname = 'crystal-lang'; // required: replace example with your forum shortname
-    var disqus_identifier = '{{ page.id }}';
-    var disqus_title = {{ page.title | jsonify }};
-    var disqus_url = "http://crystal-lang.org/{{ page.url }}";
-
-    /* * * DON'T EDIT BELOW THIS LINE * * */
-    (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-    })();
-  </script>
-  <noscript>
-    Please enable JavaScript to view the
-    <a href='http://disqus.com/?ref_noscript'>comments powered by Disqus.</a>
-  </noscript>
-  <a class='dsq-brlink' href='http://disqus.com'>
-    comments powered by
-    <span class='logo-disqus'>Disqus</span>
-  </a>
 </main>

--- a/_posts/2019-09-06-parallelism-in-crystal.md
+++ b/_posts/2019-09-06-parallelism-in-crystal.md
@@ -2,6 +2,7 @@
 title: Parallelism in Crystal
 summary: Use more of your core power
 author: waj,bcardiff
+comment_href: https://disqus.com/home/discussion/crystal-lang/parallelism_in_crystal_88/
 ---
 
 Crystal has made a huge step forward to have parallelism as a first class citizen. In short, you can set up the number of worker threads on runtime and each new fiber will be scheduled to run on one of them. Channel and select will work seamlessly. You are allowed to share memory between workers, but you will probably need to take care of some synchronization to keep the state consistent.

--- a/_posts/2020-01-02-introducing-shardbox.md
+++ b/_posts/2020-01-02-introducing-shardbox.md
@@ -2,6 +2,7 @@
 title: Introducing shardbox.org
 summary: A platform for discovering the shards ecosystem.
 author: straight-shoota
+comment_href: https://disqus.com/home/discussion/crystal-lang/introducing_shardboxorg_45/
 ---
 
 I'm happy to announce the launch of [shardbox.org](https://shardbox.org), a database for discovering shards.

--- a/_posts/2020-02-02-alpine-based-docker-images.md
+++ b/_posts/2020-02-02-alpine-based-docker-images.md
@@ -2,6 +2,7 @@
 title: Alpine-based Docker images
 summary: Using Crystal with brand new Docker images based on Alpine Linux
 author: straight-shoota
+comment_href: https://disqus.com/home/discussion/crystal-lang/alpine_based_docker_images/
 ---
 
 

--- a/_posts/2020-03-03-towards-crystal-1.0.md
+++ b/_posts/2020-03-03-towards-crystal-1.0.md
@@ -3,6 +3,7 @@ title: Towards Crystal 1.0
 summary: The upcoming efforts to release Crystal 1.0
 thumbnail: +
 author: bcardiff
+comment_href: https://disqus.com/home/discussion/crystal-lang/towards_crystal_10_23/
 ---
 
 Currently the main goal of the Crystal core team is to reach 1.0 in the near future. Since achieving that goal involves a number of non-obvious tradeoffs, we want to use this post to shed some light on those inherent tensions and how they drive our work and priorities for the next few releases.

--- a/_posts/2020-08-20-preparing-our-shards-for-crystal-1.0.md
+++ b/_posts/2020-08-20-preparing-our-shards-for-crystal-1.0.md
@@ -3,6 +3,7 @@ title: Preparing our shards for Crystal 1.0
 summary: How we can prepare our shards for Crystal 1.0 or for upstream changes of dependencies at any time.
 thumbnail: +
 author: bcardiff
+comment_href: https://disqus.com/home/discussion/crystal-lang/preparing_our_shards_for_crystal_10/
 ---
 
 A shard always has one or more dependencies. These dependencies are subject to change. The author might be more or less conservative regarding any breaking-changes. I want to revisit what are the mechanisms to check if the shard we are working on is up to date with the upcoming changes of its dependencies.

--- a/_posts/2020-11-19-organising-raw-crystal.md
+++ b/_posts/2020-11-19-organising-raw-crystal.md
@@ -3,6 +3,7 @@ title: Organising a Crystal conference in 2020
 summary: An overview of what you can expect at Raw Crystal 2020 and some insight on the organisation process.
 thumbnail: +
 author: lbarasti
+comment_href: https://disqus.com/home/discussion/crystal-lang/organising_a_crystal_conference_in_2020/
 ---
 
 Since I started exploring Crystal, I've always been impressed with how supportive people in the community were. It's the kind of feeling that makes you look forward to engage with fellow humans sharing a passion for building things.

--- a/_posts/2021-03-22-crystal-core-team-announcements.md
+++ b/_posts/2021-03-22-crystal-core-team-announcements.md
@@ -4,6 +4,7 @@ summary: A lot has been going on in the Crystal Core Team ...
 thumbnail: +
 author: nditada
 release_notes: false
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_core_team_announcements/
 ---
 
 A lot has been going on in the Crystal Core Team, and the community has voiced its need for more (and more frequent) communication. This post is an attempt to catch up with that. I'm taking the license of using "we" for both Crystal and Manas.Tech in this short update.

--- a/_posts/2021-06-01-behind-the-scenes.md
+++ b/_posts/2021-06-01-behind-the-scenes.md
@@ -3,6 +3,7 @@ title: Behind the scenes of the past two months
 summary: What’s been going on after the 1.0 release
 thumbnail: +
 author: beta-ziliani
+comment_href: https://disqus.com/home/discussion/crystal-lang/behind_the_scenes_of_the_past_two_months/
 ---
 
 A couple of months since the first official release, the steam of PR reviewing and merging has appeased a bit. This gives us an opportunity to share some of what’s been happening behind the scenes: a bunch of big things are coming!

--- a/_posts/2021-09-30-preparing-1.2.md
+++ b/_posts/2021-09-30-preparing-1.2.md
@@ -3,6 +3,7 @@ title: Preparing for Crystal 1.2
 summary: Lowering 32-bit support in favor of more popular platforms
 thumbnail: +
 author: beta-ziliani
+comment_href: https://disqus.com/home/discussion/crystal-lang/preparing_for_crystal_12/
 ---
 
 We have reached the feature freeze period for Crystal 1.2. From now on, only bug fixes will be merged into master. The release is scheduled for the 13th of October. As usual, we invite everyone to test our latest nightly release to ensure that we haven't included a breaking change by mistake ([docker 🐳](https://hub.docker.com/r/crystallang/crystal/tags?page=1&ordering=last_updated&name=nightly), [OS packages 💻](https://crystal-lang.org/install/)).

--- a/_posts/2021-12-29-crystal-i.md
+++ b/_posts/2021-12-29-crystal-i.md
@@ -3,6 +3,7 @@ title: Crystal's interpreter – A very special holiday present
 summary: A little F.A.Q. about this new feature
 thumbnail: +
 author: beta-ziliani
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystals_interpreter_a_very_special_holiday_present_98/
 ---
 
 The awaited Crystal interpreter has been [merged](https://github.com/crystal-lang/crystal/pull/11159). To use it, you need to compile Crystal with a special flag and, at the time of writing, the official releases (.deb, .rpm, docker images, etc.) are not being compiled with it.

--- a/_posts/2023-01-05-welcome-2023.md
+++ b/_posts/2023-01-05-welcome-2023.md
@@ -3,6 +3,7 @@ title: Welcome 2023!
 summary: The new year comes with lots of good news.
 thumbnail: +
 author: beta-ziliani
+comment_href: https://disqus.com/home/discussion/crystal-lang/welcome_2023_18/
 ---
 
 Hello everyone, and happy New Year! We’re kicking off 2023 with some exciting changes that we want to share with you.

--- a/_posts/2023-01-24-placeos-environments.md
+++ b/_posts/2023-01-24-placeos-environments.md
@@ -2,6 +2,7 @@
 title: "Automating smart buildings with Crystal: how PlaceOS creates and manages cohesive environments"
 author: stakach,pettimart
 summary: "<b>Stephen Von Takach Dukai</b>, <b>Engineering Lead</b> at PlaceOS, talks about their experience working with Crystal."
+comment_href: https://disqus.com/home/discussion/crystal-lang/automating_smart_buildings_with_crystal_how_placeos_creates_and_manages_cohesive_environments/
 ---
 <img src="/assets/blog/2023-01-24-placeos.png" class="center" />
 

--- a/_posts/2023-03-02-crystal-is-upgrading-its-regex-engine.md
+++ b/_posts/2023-03-02-crystal-is-upgrading-its-regex-engine.md
@@ -2,6 +2,7 @@
 title: "Heads up: Crystal is upgrading its Regex engine"
 author: beta-ziliani
 summary: "Crystal is upgrading from PCRE to PCRE2"
+comment_href: https://disqus.com/home/discussion/crystal-lang/heads_up_crystal_is_upgrading_its_regex_engine/
 ---
 
 Crystal uses since its inception the [PCRE](https://www.pcre.org/) library for dealing with regular expressions. This library has two major versions, and Crystal so far resorted to the first one (PCRE). However, this version reached its end of life. Therefore, for the next release (1.8) we are planning to move to its successor, PCRE2.

--- a/_posts/2023-03-06-reveal-type-in-crystal.md
+++ b/_posts/2023-03-06-reveal-type-in-crystal.md
@@ -2,6 +2,7 @@
 title: "Reveal type in Crystal"
 author: bcardiff
 summary: "Porting reveal_type from Sorbet to Crystal."
+comment_href: https://disqus.com/home/discussion/crystal-lang/reveal_type_in_crystal_42/
 ---
 
 Recently I came across [`reveal_type` from Sorbet](https://sorbet.org/docs/flow-sensitive#example) as a way to inspect the type of an expression, thanks [Brian Hicks](https://bytes.zone/). I wondered if that can be ported to Crystal. You can jump to the [conclusions](#conclusions) section if you want to copy-paste the good-enough™️ solution in your project.

--- a/_posts/2023-03-23-llvm-opaque-pointers.md
+++ b/_posts/2023-03-23-llvm-opaque-pointers.md
@@ -2,6 +2,7 @@
 title: "LLVM opaque pointer support has landed"
 author: HertzDevil
 summary: Updates to the LLVM bindings bring support for LLVM 15+ and significant improvements in codegen performance in the next release.
+comment_href: https://disqus.com/home/discussion/crystal-lang/llvm_opaque_pointer_support_has_landed_99/
 ---
 
 Crystal 1.8, the upcoming minor release, will support LLVM's opaque pointers for the first time, allowing the compiler to be built with LLVM 15 or above. Additionally, this update brings a significant improvement to compilation times.

--- a/_posts/2023-07-19-Remilia-interview.md
+++ b/_posts/2023-07-19-Remilia-interview.md
@@ -2,6 +2,7 @@
 title: "Interview with contributor Remilia Scarlet"
 author: beta-ziliani,Remilia
 summary: "Music playback projects in Crystal, games engines, and a bit of Lisp"
+comment_href: https://disqus.com/home/discussion/crystal-lang/interview_with_contributor_remilia_scarlet/
 ---
 
 Remilia Scarlet has been working with Crystal for her audio projects for a while now. We ask her about this experience, and here is what she has to say:

--- a/_posts/2023-11-09-memories-from-crystalconf.md
+++ b/_posts/2023-11-09-memories-from-crystalconf.md
@@ -2,6 +2,7 @@
 title: Memories from CrystalConf
 author: straight-shoota
 summary: Impressions from the conference in Berlin
+comment_href: https://disqus.com/home/discussion/crystal-lang/memories_from_crystalconf/
 ---
 
 CrystalConf 2023 was a sounding success with a terrific lineup of speakers and talks.

--- a/_posts/2023-11-15-bright-manas-partnership.md
+++ b/_posts/2023-11-15-bright-manas-partnership.md
@@ -2,6 +2,7 @@
 title: "Bright and Manas partner together to create Crystal development tools"
 author: beta-ziliani
 summary: "The story behind four development tools that were released recently"
+comment_href: https://disqus.com/home/discussion/crystal-lang/bright_and_manas_partner_together_to_create_crystal_development_tools_37/
 ---
 
 <div class="center">

--- a/_posts/2024-01-19-windows-support-1.11.md
+++ b/_posts/2024-01-19-windows-support-1.11.md
@@ -2,6 +2,7 @@
 title: "Windows support in Crystal 1.11"
 author: HertzDevil
 summary: Playground, preliminary interpreter support, and better dynamic linking
+comment_href: https://disqus.com/home/discussion/crystal-lang/windows_support_in_crystal_111_67/
 ---
 
 It has been 6 months since we last reported on the [status of Windows support in Crystal 1.9](/2023/07/06/windows-support-1.9). Although there aren't as many changes in [1.10](https://github.com/crystal-lang/crystal/pulls?q=is%3Apr+milestone%3A1.10.0+is%3Aclosed+label%3Aplatform%3Awindows) and [1.11](https://github.com/crystal-lang/crystal/pulls?q=is%3Apr+milestone%3A1.11.0+is%3Aclosed+label%3Aplatform%3Awindows), we have nonetheless made some significant breakthroughs which will be described below.

--- a/_releases/2019-08-01-crystal-0.30.0-released.md
+++ b/_releases/2019-08-01-crystal-0.30.0-released.md
@@ -4,6 +4,7 @@ version: 0.30.0
 summary: Crystal has a new development release.
 thumbnail: +
 author: bcardiff
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_0300_released/
 ---
 
 [Crystal 0.30.0](https://github.com/crystal-lang/crystal/releases/tag/0.30.0) has been released!

--- a/_releases/2019-09-23-crystal-0.31.0-released.md
+++ b/_releases/2019-09-23-crystal-0.31.0-released.md
@@ -4,6 +4,7 @@ version: 0.31.0
 summary: Crystal has a new development release.
 thumbnail: +
 author: bcardiff
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_0310_released/
 ---
 
 [Crystal 0.31.0](https://github.com/crystal-lang/crystal/releases/tag/0.31.0) has been released!

--- a/_releases/2019-12-11-crystal-0.32.0-released.md
+++ b/_releases/2019-12-11-crystal-0.32.0-released.md
@@ -4,6 +4,7 @@ version: 0.32.0
 summary: Crystal has a new development release.
 thumbnail: +
 author: bcardiff,ftarulla
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_0320_released/
 ---
 
 [Crystal 0.32.0](https://github.com/crystal-lang/crystal/releases/tag/0.32.0) has been released!

--- a/_releases/2019-12-18-crystal-0.32.1-released.md
+++ b/_releases/2019-12-18-crystal-0.32.1-released.md
@@ -4,6 +4,7 @@ version: 0.32.1
 summary: Crystal has a new development release.
 thumbnail: +
 author: bcardiff
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_0321_released/
 ---
 
 [Crystal 0.32.1](https://github.com/crystal-lang/crystal/releases/tag/0.32.1) has been released!

--- a/_releases/2020-02-14-crystal-0.33.0-released.md
+++ b/_releases/2020-02-14-crystal-0.33.0-released.md
@@ -4,6 +4,7 @@ version: 0.33.0
 summary: Crystal has a new development release.
 thumbnail: +
 author: bcardiff
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_0330_released/
 ---
 
 [Crystal 0.33.0](https://github.com/crystal-lang/crystal/releases/tag/0.33.0) has been released!

--- a/_releases/2020-04-06-crystal-0.34.0-released.md
+++ b/_releases/2020-04-06-crystal-0.34.0-released.md
@@ -4,6 +4,7 @@ version: 0.34.0
 summary: Crystal has a new development release.
 thumbnail: +
 author: bcardiff
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_0340_released/
 ---
 
 

--- a/_releases/2020-06-09-crystal-0.35.0-released.md
+++ b/_releases/2020-06-09-crystal-0.35.0-released.md
@@ -4,6 +4,7 @@ version: 0.35.0
 summary: Crystal has a new development release.
 thumbnail: +
 author: bcardiff
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_0350_released/
 ---
 
 

--- a/_releases/2021-01-26-crystal-0.36.0-released.md
+++ b/_releases/2021-01-26-crystal-0.36.0-released.md
@@ -4,6 +4,7 @@ version: 0.36.0
 summary: Crystal has a new development release.
 thumbnail: +
 author: bcardiff
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_0360_released/
 ---
 
 

--- a/_releases/2021-02-02-crystal-0.36.1-released.md
+++ b/_releases/2021-02-02-crystal-0.36.1-released.md
@@ -4,6 +4,7 @@ version: 0.36.1
 summary: Crystal has a new development release.
 thumbnail: +
 author: bcardiff
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_0361_released/
 ---
 
 

--- a/_releases/2021-03-22-crystal-1.0-what-to-expect.md
+++ b/_releases/2021-03-22-crystal-1.0-what-to-expect.md
@@ -4,6 +4,7 @@ version: 1.0.0
 summary: Crystal 1.0.0 is here
 thumbnail: +
 author: asterite,bcardiff,waj,450
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_10_what_to_expect_51/
 ---
 
 The release of the first major release of Crystal arrives after many years of hard work. With thousands of contributions from people worldwide, it was finally possible to find consensus for what truly mattered for 1.0 and what could wait for future releases. Getting here wasn’t an easy journey, filled with enriching, controversial, delightful, and endless conversations that, in the end, made it possible to build a language more useful for more users.

--- a/_releases/2021-07-16-1.1.0-released.md
+++ b/_releases/2021-07-16-1.1.0-released.md
@@ -4,6 +4,7 @@ version: 1.1.0
 summary: The first post-1.0 release
 thumbnail: +
 author: beta-ziliani
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_110_is_released/
 ---
 
 We are releasing the first post-1.0 release, making efforts to keep our promise of making regular releases each 3 months, a bit delayed because of the [conference](/conference), and with special focus on keeping the language stability. Below we list the most important or interesting changes, without mentioning the several bugfixes. For details visit the [release's notes](https://github.com/crystal-lang/crystal/releases/tag/1.1.0).

--- a/_releases/2021-10-14-1.2.0-released.md
+++ b/_releases/2021-10-14-1.2.0-released.md
@@ -4,6 +4,7 @@ version: 1.2.0
 summary: Improving platform support
 thumbnail: +
 author: beta-ziliani
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_120_is_released_32/
 ---
 
 We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning the several bugfixes. For details visit the [release's notes](https://github.com/crystal-lang/crystal/releases/tag/1.2.0). Breaking changes are marked with ⚠️.

--- a/_releases/2022-04-06-1.4.0-released.md
+++ b/_releases/2022-04-06-1.4.0-released.md
@@ -4,6 +4,7 @@ version: 1.4.0
 summary:
 thumbnail: +
 author:
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_140_is_released/
 ---
 
 Celebrating the first year of the 1.X series of our beloved language, we are delivering a new release with several bugfixes and improvements.

--- a/_releases/2022-09-08-1.5.1-released.md
+++ b/_releases/2022-09-08-1.5.1-released.md
@@ -4,6 +4,7 @@ version: 1.5.1
 summary:
 thumbnail: +
 author:
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_151_is_released/
 ---
 
 We are releasing the first patch release of the [1.5](https://crystal-lang.org/2022/07/06/1.5.0-released.html) series.

--- a/_releases/2022-10-06-1.6.0-released.md
+++ b/_releases/2022-10-06-1.6.0-released.md
@@ -4,6 +4,7 @@ version: 1.6.0
 summary:
 thumbnail: +
 author:
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_160_is_released/
 ---
 
 We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements. For more details, visit the [changelog](https://github.com/crystal-lang/crystal/releases/tag/1.6.0). Breaking changes are marked with ⚠️.

--- a/_releases/2022-10-21-1.6.1-released.md
+++ b/_releases/2022-10-21-1.6.1-released.md
@@ -4,6 +4,7 @@ version: 1.6.1
 summary:
 thumbnail: +
 author:
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_161_is_released_45/
 ---
 
 We are releasing the first patch release of the [1.6](/2022/10/06/1.6.0-released/) series.

--- a/_releases/2023-01-09-1.7.0-released.md
+++ b/_releases/2023-01-09-1.7.0-released.md
@@ -4,6 +4,7 @@ version: 1.7.0
 summary:
 thumbnail: +
 author:
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_170_is_released/
 ---
 
 We are starting the year with a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements. For more details, visit the [changelog](https://github.com/crystal-lang/crystal/releases/tag/1.7.0). Breaking changes are marked with ⚠️.

--- a/_releases/2023-04-14-1.8.0-released.md
+++ b/_releases/2023-04-14-1.8.0-released.md
@@ -4,6 +4,7 @@ version: 1.8.0
 summary:
 thumbnail: +
 author:
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_180_is_released_85/
 ---
 
 We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements. For more details, visit the [changelog](https://github.com/crystal-lang/crystal/releases/tag/1.8.0). Breaking changes are marked with ⚠️.

--- a/_releases/2023-10-09-1.10.0-released.md
+++ b/_releases/2023-10-09-1.10.0-released.md
@@ -4,6 +4,7 @@ version: 1.10.0
 summary:
 thumbnail: +
 author: straight-shoota
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_1100_is_released/
 ---
 
 We are delivering a new Crystal release with several bugfixes and improvements.

--- a/_releases/2023-10-13-1.10.1-released.md
+++ b/_releases/2023-10-13-1.10.1-released.md
@@ -4,6 +4,7 @@ version: 1.10.1
 summary:
 thumbnail: +
 author: straight-shoota
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_1101_is_released/
 ---
 
 We are announcing a new patch release of the Crystal [1.10](/2023/10/09/1.10.0-released/)

--- a/_releases/2024-01-08-1.11.0-released.md
+++ b/_releases/2024-01-08-1.11.0-released.md
@@ -4,6 +4,7 @@ version: 1.11.0
 date: 2024-01-08
 summary:
 author: straight-shoota
+comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_1110_is_released/
 ---
 We are announcing a new Crystal release with several new features and bug fixes.
 


### PR DESCRIPTION
This is a preparatory step for #560 to retain archive links to existing comments.