### PR TITLE
Install: Introduce `archive_href` to autogenerate package download links

### DIFF
--- a/_data/packages-nightly.yaml
+++ b/_data/packages-nightly.yaml
@@ -16,9 +16,9 @@
 - type: crystal
   os: Linux
   arch: [x86_64]
-  title: Tarball
+  title: Tarball (`.tar.gz`)
   instructions_href: /install/from_targz/
-  example: 'Archive on [artifacts.crystal-lang.org](https://artifacts.crystal-lang.org/dist/crystal-nightly-linux-x86_64.tar.gz).'
+  archive_href: https://artifacts.crystal-lang.org/dist/crystal-nightly-linux-{{ arch }}.tar.gz
 
 - type: community
   os: Linux
@@ -48,9 +48,9 @@
 - type: crystal
   os: MacOS
   arch: [universal]
-  title: Tarball
+  title: Tarball (`.tar.gz`)
   instructions_href: /install/from_targz/
-  example: 'Archive on [artifacts.crystal-lang.org](https://artifacts.crystal-lang.org/dist/crystal-nightly-darwin-universal.tar.gz).'
+  archive_href: https://artifacts.crystal-lang.org/dist/crystal-nightly-darwin-universal.tar.gz
 
 - type: community
   os: MacOS
@@ -68,16 +68,16 @@
 - type: crystal
   os: Windows
   arch: [x86_64]
-  title: Installer
+  title: Installer (`.exe`)
   instructions_href: /install/on_windows/
-  example: Installer (`.exe`) on [artifacts.crystal-lang.org](https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal-installer.zip).
+  archive_href: https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal-installer.zip
 
 - type: crystal
   os: Windows
   arch: [x86_64]
-  title: Portable Archive
+  title: Portable Archive (`.zip`)
   instructions_href: /install/on_windows/
-  example: Archive (`.zip`) on [artifacts.crystal-lang.org](https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal.zip).
+  archive_href: https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal.zip
 
 - type: community
   os: Windows

--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -16,10 +16,10 @@
 
 - type: crystal
   os: Linux
-  arch: [x86_64]
-  title: Tarball
+  arch: [x86_64, x86_64-bundled]
+  title: Tarball (`.tar.gz`)
   instructions_href: /install/from_targz/
-  example: 'Archive in [the latest release](https://github.com/crystal-lang/crystal/releases).'
+  archive_href: https://github.com/crystal-lang/crystal/releases/download/{{ version }}/crystal-{{ version }}-1-linux-x86_64.tar.gz
   repology: crystal
 
 - type: system
@@ -131,9 +131,9 @@
 - type: crystal
   os: MacOS
   arch: [universal]
-  title: Tarball
+  title: Tarball (`.tar.gz`)
   instructions_href: /install/from_targz/
-  example: 'Archive in the [the latest release](https://github.com/crystal-lang/crystal/releases).'
+  archive_href: https://github.com/crystal-lang/crystal/releases/download/{{ version }}/crystal-{{ version }}-1-darwin-universal.tar.gz
   repology: crystal
 
 - type: community
@@ -187,17 +187,17 @@
 - type: crystal
   os: Windows
   arch: [x86_64]
-  title: Installer
+  title: Installer (`.exe`)
   instructions_href: /install/on_windows/
-  example: Installer (`.exe`) in [the latest release](https://github.com/crystal-lang/crystal/releases).
+  archive_href: https://github.com/crystal-lang/crystal/releases/download/{{ version }}/crystal-{{ version }}-1-windows-{{ arch }}-msvc-unsupported.exe
   repology: crystal
 
 - type: crystal
   os: Windows
   arch: [x86_64]
-  title: Portable Archive
+  title: Portable Archive (`.zip`)
   instructions_href: /install/on_windows/
-  example: Archive (`.zip`) in [the latest release](https://github.com/crystal-lang/crystal/releases).
+  archive_href: https://github.com/crystal-lang/crystal/releases/download/{{ version }}/crystal-{{ version }}-1-windows-{{ arch }}-msvc-unsupported.zip
   repology: crystal
 
 - type: community

--- a/_includes/pages/install/group.html
+++ b/_includes/pages/install/group.html
@@ -1,6 +1,7 @@
 {% assign entries = site.data[include.dataset] | where: "os", include.os | where: "type", include.type %}
 {% assign size = entries | size %}
 {% assign latest_release = site.releases | reverse | first %}
+{% assign version = latest_release.version %}
 {% if size > 0 %}
 <div class="install-group">
   <h3>{{ include.type | capitalize }}</h3>
@@ -11,7 +12,7 @@
           {% if entry.instructions_href %}
             <a href="{{ entry.instructions_href }}" title="Instructions for {{ entry.label | default: entry.title }}">
           {% endif %}
-          {{ entry.title }}
+          {{ entry.title | markdownify }}
           {% if entry.instructions_href %}
             </a>
           {% endif %}
@@ -25,11 +26,19 @@
         </span>
         {% endif %}
         {% if entry.repology == "crystal" %}
-          <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge" alt="Latest version: {{ latest_release.version }}"></span>
+          <span class="repo-badge"><img src="/assets/install/version-badge.svg" class="version-badge" alt="Latest version: {{ version }}"></span>
         {% elsif entry.repology %}
           {% include elements/repology_badge.html repo=entry.repology %}
         {% endif %}
         <div class="example">
+          {% if entry.archive_href %}
+            <p>
+              Download:
+              {% for arch in entry.arch %}
+                <a href="{{ entry.archive_href | liquify }}"><code class="low-key">{{ arch }}</code></a>
+              {% endfor %}
+            </p>
+          {% endif %}
           {{ entry.example | markdownify }}
         </div>
         {% if entry.repo_href %}

--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -139,8 +139,14 @@ pre {
 
 :not(pre) > code,
 dd > pre {
-  padding: 0.2em 0.4em;
-  border-radius: 6px;
+  &:not(.low-key) {
+    padding: 0.2em 0.4em;
+    border-radius: 6px;
+  }
+}
+.title :not(pre) > code {
+  background: transparent;
+  padding: 0;
 }
 
 kbd {


### PR DESCRIPTION
This patch autogenerates direct links to versioned download artifacts.

**Before:**
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/35d9a097-0fc4-45c5-a5eb-3e935605b56e)

Link target: https://github.com/crystal-lang/crystal/releases

**After:**
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/02c2443b-3875-46cb-8386-4777960fecb0)


Link target: https://github.com/crystal-lang/crystal/releases/download/1.11.1/crystal-1.11.1-1-linux-x86_64.tar.gz

(note the version is not up to date in the release branch because #563 hasn't been merged in yet - it's only in master)