### PR TITLE
Add table with all archive download links

### DIFF
--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -189,7 +189,7 @@
   arch: [x86_64]
   title: Installer (`.exe`)
   instructions_href: /install/on_windows/
-  archive_href: https://github.com/crystal-lang/crystal/releases/download/{{ version }}/crystal-{{ version }}-1-windows-{{ arch }}-msvc-unsupported.exe
+  archive_href: https://github.com/crystal-lang/crystal/releases/download/{{ version }}/crystal-{{ version }}-windows-{{ arch }}-msvc-unsupported.exe
   repology: crystal
 
 - type: crystal
@@ -197,7 +197,7 @@
   arch: [x86_64]
   title: Portable Archive (`.zip`)
   instructions_href: /install/on_windows/
-  archive_href: https://github.com/crystal-lang/crystal/releases/download/{{ version }}/crystal-{{ version }}-1-windows-{{ arch }}-msvc-unsupported.zip
+  archive_href: https://github.com/crystal-lang/crystal/releases/download/{{ version }}/crystal-{{ version }}-windows-{{ arch }}-msvc-unsupported.zip
   repology: crystal
 
 - type: community

--- a/_includes/pages/install/archive-table.html
+++ b/_includes/pages/install/archive-table.html
@@ -1,0 +1,24 @@
+<table>
+  <caption>{{ include.caption }}</caption>
+  <thead>
+    <th>OS</th>
+    <th>Type</th>
+    <th width="55%">Download</th>
+  </thead>
+  {% assign entries = include.packages | where_exp: "entry", "entry.archive_href" %}
+  {% assign latest_release = site.releases | reverse | first %}
+  {% assign version = latest_release.version %}
+  <tbody>
+    {% for entry in entries %}
+    <tr>
+      <th>{{ entry.os }}</th>
+      <td>{{ entry.title | markdownify }}</td>
+      <td>
+        {% for arch in entry.arch %}
+          <a href="{{ entry.archive_href | liquify }}"><code class="low-key">{{ arch }}</code></a>{% unless forloop.last %}, {% endunless %}
+        {% endfor %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/_pages/install/from_targz.md
+++ b/_pages/install/from_targz.md
@@ -20,3 +20,11 @@ Then you can invoke the compiler by just typing:
 ```bash
 crystal --version
 ```
+
+{% assign latest_release = site.releases | reverse | first %}
+{% capture caption %}
+Downloads for latest release {{ latest_release.version }}
+{% endcapture %}
+
+{% include pages/install/archive-table.html packages=site.data.packages caption=caption %}
+{% include pages/install/archive-table.html packages=site.data.packages-nightly caption="Downloads for nightly build" %}


### PR DESCRIPTION
This is one of the fruits from #570: We can easily display package information in other places.

![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/c31324e2-df00-40e9-b446-f4c2091944f5)
