### PR TITLE
Add `@HertzDevil` to `blog_authors`

### DIFF
--- a/_data/blog_authors.json
+++ b/_data/blog_authors.json
@@ -73,5 +73,8 @@
   },
   "Remilia": {
     "name": "Remilia Scarlet"
+  },
+  "HertzDevil": {
+    "name": "Quinton Miller"
   }
 }


### PR DESCRIPTION
Quinton is missing from the authors data, which renders as anonymous authorshipt ;)

![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/02132b61-369c-44b1-8f42-c70f9dcbcb3e)

Of course the template should also fall back to display the handle.