### PR TITLE
Ensure `.centered` is actually centered in wide containers

### DIFF
--- a/_sass/utilities/_text.scss
+++ b/_sass/utilities/_text.scss
@@ -1,5 +1,8 @@
 .center {
   text-align: center;
+  align-self: center;
+  justify-self: center;
+  margin-inline: auto;
 }
 
 .small {


### PR DESCRIPTION
Before:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/fefe15e0-1777-45de-a2f4-162192ff0ec6)


After:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/d7adce81-b688-43f5-afdc-644b1f617193)
