### PR TITLE
Ignore github.com and twitter.com in link checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ check_external_links: $(O) $(htmlproofer) ## Validates external links in generat
 	$(htmlproofer) $(O) \
 		--assume-extension \
 		--url-swap "\A\/(api|docs|images|reference):https://crystal-lang.org/\1" \
-		--url-ignore "http://0.0.0.0:8080" \
+		--url-ignore "/github.com/,/twitter.com/" \
 		--http-status-ignore 999 \
 		--external_only \
 		$(if $(cache),--timeframe '30d',)


### PR DESCRIPTION
They don't seem to be reporting correct results anyway. Especially github.com is flooded by too many requests and turns them all down.