### PR TITLE
Move scss functions to main layer

### DIFF
--- a/_sass/components/_featured-posts.scss
+++ b/_sass/components/_featured-posts.scss
@@ -1,9 +1,3 @@
-@use "sass:map";
-
-@function font-size($key) {
-  @return map.get($font-sizes, $key);
-}
-
 .featured-posts {
   margin-block-start: var(--block-flow-sm);
   display: grid;

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -7,6 +7,8 @@
 @import "mixins/external-links";
 @import "mixins/link-with-icon";
 
+@import "base/functions";
+
 @layer reset {
   @import "reset";
 }
@@ -16,7 +18,6 @@
 }
 
 @layer defaults {
-  @import "base/functions";
   @import "base/fonts";
   @import "base/typography";
   @import "base/layout";


### PR DESCRIPTION
This allows using the function from another layer where it previously was duplicated.