### PR TITLE
Refactor `link-with-icon` to use mask

### DIFF
--- a/_sass/mixins/_link-with-icon.scss
+++ b/_sass/mixins/_link-with-icon.scss
@@ -14,13 +14,14 @@
     mask-repeat: no-repeat;
     mask-position: center;
     mask-size: contain;
+    mask-image: var(--link-icon);
   }
 }
 
 @mixin link-with-icon-href($href, $image) {
   &[href^="#{$href}"]::before {
     content: "";
-    mask-image: $image;
+    --link-icon: #{$image};
   }
 }
 
@@ -29,6 +30,6 @@
 
   &:before {
     content: "";
-    mask-image: $image;
+    --link-icon: #{$image};
   }
 }

--- a/_sass/mixins/_link-with-icon.scss
+++ b/_sass/mixins/_link-with-icon.scss
@@ -5,24 +5,22 @@
   &::before,
   > img {
     width: 1.3em;
-    height: 1.3em;
-    background-repeat: no-repeat;
+    aspect-ratio: 1;
     object-fit: contain;
     margin-inline-end: var(--padding-xxs);
   }
-
-  &:hover {
-    &::before,
-    > img {
-      opacity: 0.72;
-    }
+  &::before {
+    background-color: currentColor;
+    mask-repeat: no-repeat;
+    mask-position: center;
+    mask-size: contain;
   }
 }
 
-@mixin link-with-icon-href($href, $url) {
+@mixin link-with-icon-href($href, $image) {
   &[href^="#{$href}"]::before {
     content: "";
-    background-image: #{$url};
+    mask-image: $image;
   }
 }
 
@@ -31,6 +29,6 @@
 
   &:before {
     content: "";
-    background-image: $image;
+    mask-image: $image;
   }
 }


### PR DESCRIPTION
This enables better color control over the icon. We're using the same setup for exteral links.