### PR TITLE
Remove border around cards

### DIFF
--- a/_includes/media/color_sample.html
+++ b/_includes/media/color_sample.html
@@ -1,4 +1,4 @@
-<div class="card card--borderless">
+<div class="card">
   <div class="color-sample" style="--color-sample-color: {{ include.hex }};{% if include.color == 'Black' %} --color-sample-border: #000;{% endif %}"></div>
   <span class="name">{{ include.color }}</span>
   <code class="low-key">{{ include.hex }}</code>

--- a/_sass/components/_card.scss
+++ b/_sass/components/_card.scss
@@ -1,10 +1,4 @@
 .card {
-  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 20%), 0 1px 3px 0 rgb(0 0 0 / 10%);
-
-  &.card--borderless {
-    box-shadow: none;
-  }
-
   padding: var(--padding-xs);
   display: flex;
   flex-direction: column;

--- a/_sass/components/event-card.scss
+++ b/_sass/components/event-card.scss
@@ -13,7 +13,6 @@
 
   @extend .card;
 
-  box-shadow: none;
   width: auto;
   align-items: start;
   text-align: start;


### PR DESCRIPTION
Removes the border around card components. This removes visual disturbance and foucses more on the content.

This may be a bit of a controversial change. The card visuals have been - in my understanding - an integral part of the design language for a long time.
But I think it makes a lot of sense to drop the border while keeping all the other aesthetics of the design. This fits very well with the theme of the site that we have reached now with a clean look.

#### Before
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/9df8dfa4-32d0-498a-9c15-1d8d9753c8b2)

#### After
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/c70e888c-e723-427d-934b-dd128c011424)

As a minor detail, without an enclosure some of the profile link icons might now seem a bit uncoupled from the main part (especially for Jonne and Serdar in the first row). I don't think this is too much of an issue, but we could also tweak the positining and move those icons to a different position and puts the `roles` property with widely varying height on the bottom

The card style is also used for top sponsors and on the media page (the color cards where already borderless). The borderless appearance works there as well:

![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/be1e5944-7ab3-4f01-91c3-7cab2c58e637)

![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/bbf99bb5-0128-44ca-94b3-0a2021637920)

