### PR TITLE
Fix broken hover effect on release links

### DIFF
--- a/_includes/pages/releases/releases-table.html
+++ b/_includes/pages/releases/releases-table.html
@@ -19,7 +19,7 @@
             <span class="pill">latest</span>
           {% endif %}
         </td>
-        <td>
+        <td class="release-links">
           {% include releases/links.html release = release %}
         </td>
       </tr>

--- a/_sass/pages/_releases.scss
+++ b/_sass/pages/_releases.scss
@@ -22,11 +22,7 @@ table.releases {
     white-space: nowrap;
   }
 
-  .release-links {
-    &:not(:hover) {
-      > a {
-        opacity: 0.25;
-      }
-    }
+  .release-links:not(:hover) {
+    opacity: 0.25;
   }
 }


### PR DESCRIPTION
This was broken in #573 due to a change of class name.