### PR TITLE
Highlight minor releases

### DIFF
--- a/_includes/pages/releases/releases-table.html
+++ b/_includes/pages/releases/releases-table.html
@@ -9,7 +9,8 @@
   <tbody>
     {%- assign releases = site.releases | reverse %}
     {%- for release in releases %}
-      <tr {% if forloop.index0 == 0 %}class="latest-release"{% endif %}>
+      {%- assign suffix = release.version | slice: -2, 2 %}
+      <tr class="{% if forloop.index0 == 0 %}latest-release{% endif %}{% if suffix == '.0' %} minor-release{% endif %}">
         <th scope="row"><a href="{{ release.url }}">{{release.version}}</a></th>
         <td class="release-date">
           <time datetime="{{ release.date | date: '%F' }}">{{ release.date | date_to_string }}</time>

--- a/_sass/pages/_releases.scss
+++ b/_sass/pages/_releases.scss
@@ -9,6 +9,11 @@ table.releases {
     &.latest-release {
       border-left-color: currentcolor;
     }
+
+    &:not(.minor-release) th {
+      font-weight: 400;
+      --link-color: var(--light-text);
+    }
   }
 
   > tbody > tr:hover {


### PR DESCRIPTION
Adjusts the styling of version numbers on the releases page so that minor releases stand out a bit more than patch releases.

![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/ac4cdf0f-0698-46dc-930b-a86d1bd2859d)
