### PR TITLE
Fix consistent main-width for all pages

### DIFF
--- a/_sass/base/_layout.scss
+++ b/_sass/base/_layout.scss
@@ -18,11 +18,7 @@ body {
   min-height: 100vh;
   background-color: var(--background-main);
 
-  --main-width: min(100vw - 3rem, var(--container-max, 110ch));
-}
-
-body.layout--page {
-  --container-max: 120ch;
+  --main-width: min(100vw - 3rem, var(--container-max, 120ch));
 }
 
 body > * {


### PR DESCRIPTION
This ensures all pages have the same main width. Previously it was different which meant the position of the header nav jumped between pages.