### PR TITLE
Improve callout syling

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -99,7 +99,7 @@ kramdown:
 
 repository: crystal-lang/crystal-website
 
-callouts: ["NOTE"]
+callouts: ["INFO", "NOTE", "WARNING"]
 
 relative_links:
   enabled:     true

--- a/_includes/callout.html
+++ b/_includes/callout.html
@@ -1,7 +1,6 @@
 <aside class="callout callout--{{ include.callout }}">
-  {% if include.title %}
-    <strong class="callout-title">{{ include.title }}</strong>
-  {% endif %}
+  {%- assign title_from_callout = include.callout | capitalize %}
+  <div class="callout-title">{{ include.title | default: title_from_callout }}</div>
   <div markdown="1">
     {{ include.content }}
   </div>

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -46,7 +46,7 @@ $font-sizes: (
   --border-color: hsl(0, 0%, 87%);
   --border-color-dark: hsl(0, 0%, 84%);
 
-  --warning-light: hsl(31.2deg 100% 96%);
+  --warning: hsl(31.2deg 100% 45%);
 
   // Fonts
   // -------------

--- a/_sass/components/_callout.scss
+++ b/_sass/components/_callout.scss
@@ -1,15 +1,38 @@
 .callout {
-  background: var(--background-secondary);
-  padding: var(--padding-sm);
+  border: 1.5px solid var(--border-color-dark);
+  border-radius: 4px;
+  --content-width: auto;
+
+  --callout-color: var(--lighter-text);
+
+  @extend .small;
 
   > .callout-title {
-    display: block;
-    font-size: 120%;
-    color: var(--lighter-text);
-    font-weight: normal;
+    color: var(--light-text);
+    font-weight: 500;
+    background-color: color-mix(in srgb, var(--callout-color) 18%, transparent);
+    padding: var(--padding-xs) var(--padding-xs);
+
+    &::before {
+      content: "";
+      mask-repeat: no-repeat;
+      mask-size: contain;
+      mask-image: var(--callout-mask);
+      width: 1.3em;
+      vertical-align: text-bottom;
+      aspect-ratio: 1;
+      display: inline-block;
+      background: var(--callout-color);
+      margin-right: 0.3em;
+    }
   }
 
+  > :not(.callout-title) {
+    margin: var(--padding-xs);
+  }
+
+  --callout-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z' /%3E%3C/svg%3E");
   &--warning {
-    background-color: var(--warning-light);
+    --callout-color: var(--warning);
   }
 }

--- a/_sass/components/_callout.scss
+++ b/_sass/components/_callout.scss
@@ -32,7 +32,12 @@
   }
 
   --callout-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z' /%3E%3C/svg%3E");
+
+  &--note {
+    --callout-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12,2C6.47,2 2,6.47 2,12C2,17.53 6.47,22 12,22C17.53,22 22,17.53 22,12C22,6.47 17.53,2 12,2M15.1,7.07C15.24,7.07 15.38,7.12 15.5,7.23L16.77,8.5C17,8.72 17,9.07 16.77,9.28L15.77,10.28L13.72,8.23L14.72,7.23C14.82,7.12 14.96,7.07 15.1,7.07M13.13,8.81L15.19,10.87L9.13,16.93H7.07V14.87L13.13,8.81Z' /%3E%3C/svg%3E");
+  }
   &--warning {
     --callout-color: var(--warning);
+    --callout-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M13 14H11V9H13M13 18H11V16H13M1 21H23L12 2L1 21Z' /%3E%3C/svg%3E");
   }
 }

--- a/_style_guide/typography/callout-types.md
+++ b/_style_guide/typography/callout-types.md
@@ -1,0 +1,19 @@
+---
+title: "Callout: Types"
+type: typography
+---
+
+> **NOTE:**
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod nulla.
+> Curabitur feugiat, tortor non consequat finibus, justo purus auctor massa,
+> nec semper lorem quam in massa.
+
+> **WARNING:**
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod nulla.
+> Curabitur feugiat, tortor non consequat finibus, justo purus auctor massa,
+> nec semper lorem quam in massa.
+
+> **INFO:**
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod nulla.
+> Curabitur feugiat, tortor non consequat finibus, justo purus auctor massa,
+> nec semper lorem quam in massa.


### PR DESCRIPTION
Improve styling of callouts. They were previously very blunt, now there's a more refined style.
Also adds two new types: WARNING and INFO.

The visuals are adapted from [mkdocs-material](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) which we're already using in https://github.com/crystal-lang/crystal-book/

Before: 
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/134dd09f-6687-480d-add1-d8398498769a)

After: 
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/0f64d3e8-20e5-4be6-9291-4a1bc78afca0)
