### PR TITLE
Trim `<p>` from `markdownify` for inline elements

### DIFF
--- a/_includes/pages/home/examples.html
+++ b/_includes/pages/home/examples.html
@@ -16,7 +16,7 @@
         {{ sample.description | markdownify }}
         {%- if sample.read_more %}
           <div class="read-more">
-            {{ sample.read_more | markdownify | replace: '<p>', '' | replace: '</p>', '' }}
+            {{ sample.read_more | markdownify | remove: '<p>' | remove: '</p>' }}
           </div>
         {%- endif %}
       </div>

--- a/_includes/pages/install/archive-table.html
+++ b/_includes/pages/install/archive-table.html
@@ -12,7 +12,7 @@
     {% for entry in entries %}
     <tr>
       <th>{{ entry.os }}</th>
-      <td>{{ entry.title | markdownify }}</td>
+      <td>{{ entry.title | markdownify | remove: '<p>' | remove: '</p>' }}</td>
       <td>
         {% for arch in entry.arch %}
           <a href="{{ entry.archive_href | liquify }}"><code class="low-key">{{ arch }}</code></a>{% unless forloop.last %}, {% endunless %}

--- a/_includes/pages/install/group.html
+++ b/_includes/pages/install/group.html
@@ -20,7 +20,7 @@
           {% if entry.instructions_href %}
             <a href="{{ entry.instructions_href }}" title="Instructions for {{ entry.label | default: entry.title }}">
           {% endif %}
-          {{ entry.title | markdownify }}
+          {{ entry.title | markdownify | remove: "<p>" | remove: "</p>" -}}
           {% if entry.instructions_href %}
             </a>
           {% endif %}

--- a/_includes/site/page-header.html
+++ b/_includes/site/page-header.html
@@ -8,7 +8,7 @@
   {% if page.link_actions %}
     <nav class="link-actions">
       {% for action in page.link_actions %}
-        {{ action | markdownify }}
+        {{ action | markdownify | remove: "<p>" | remove: "</p>" }}
       {% endfor %}
     </nav>
   {% endif %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -30,7 +30,7 @@ layout: base
     {% if page.link_actions %}
       <nav class="link-actions">
         {% for action in page.link_actions %}
-          {{ action | markdownify }}
+          {{ action | markdownify | remove: "<p>" | remove: "</p>" }}
         {% endfor %}
       </nav>
     {% endif %}

--- a/_pages/used_in_prod.md
+++ b/_pages/used_in_prod.md
@@ -32,7 +32,7 @@ section: community
         {{uip.category}}
       </td>
       <td>
-        {{uip.description | markdownify}}
+        {{uip.description | markdownify | remove: "<p>" | remove: "</p>" }}
       </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
`markdownify` wraps all inline content in a block level `<p>` element. In some places we want to only apply inline styles and the easiest solution is to just remove the `<p>` tags (https://github.com/jekyll/jekyll/issues/3571).

Fixes issues like this line break inside a link:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/92144a3f-8601-47ec-a897-f3e7b8704471)
