### PR TITLE
Fix `link-with-icon-href` override by `<img>` tag

### DIFF
--- a/_sass/mixins/_link-with-icon.scss
+++ b/_sass/mixins/_link-with-icon.scss
@@ -19,7 +19,7 @@
 }
 
 @mixin link-with-icon-href($href, $image) {
-  &[href^="#{$href}"]::before {
+  &[href^="#{$href}"]:not(:has(> img))::before {
     content: "";
     --link-icon: #{$image};
   }


### PR DESCRIPTION
Fixes instances where two icons are displayed (explicit `<img>` and automatic `::before`).

![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/9f9b7e41-d7bd-4cda-b6bb-9c3f6423dcc8)
