### PR TITLE
Increase contrast for code highlighting

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -56,14 +56,14 @@ $font-sizes: (
   --md-code-hl-number-color: hsla(291, 45%, 50%, 1);
   --md-code-hl-special-color: hsla(0, 67%, 50%, 1);
   --md-code-hl-function-color: hsla(219, 54%, 51%, 1);
-  --md-code-hl-constant-color: hsla(17, 52%, 47%, 1);
+  --md-code-hl-constant-color: hsla(17, 52%, 42%, 1);
   --md-code-hl-keyword-color: hsla(219, 54%, 45%, 1);
-  --md-code-hl-string-color: hsla(130, 48%, 38%, 1);
+  --md-code-hl-string-color: hsla(130, 48%, 33%, 1);
 
   --md-code-hl-name-color: var(--md-code-fg-color);
   --md-code-hl-operator-color: var(--light-gray);
   --md-code-hl-punctuation-color: var(--light-gray);
-  --md-code-hl-comment-color: var(--lighter-gray);
+  --md-code-hl-comment-color: var(--light-gray);
   --md-code-hl-generic-color: var(--light-gray);
   --md-code-hl-variable-color: hsla(45, 28%, 38%, 1);
 

--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -18,10 +18,20 @@
   --lighter-text: var(--white);
 
   .highlight {
-    --md-code-fg-color: var(--light-text);
+    --md-code-fg-color: var(--lighter-text);
+
+    --md-code-hl-number-color: hsla(291, 45%, 65%, 1);
+    --md-code-hl-special-color: hsla(0, 67%, 65%, 1);
+    --md-code-hl-function-color: hsla(219, 54%, 68%, 1);
+    --md-code-hl-constant-color: hsla(17, 52%, 61%, 1);
+    --md-code-hl-keyword-color: hsla(219, 54%, 61%, 1);
+    --md-code-hl-string-color: hsla(130, 48%, 51%, 1);
 
     --md-code-hl-name-color: var(--md-code-fg-color);
-    --md-code-hl-comment-color: var(--light-gray);
+    --md-code-hl-operator-color: var(--lighter-gray);
+    --md-code-hl-punctuation-color: var(--lighter-gray);
+    --md-code-hl-comment-color: var(--lighter-gray);
+    --md-code-hl-generic-color: var(--lighter-gray);
   }
 
   --code-bg: hsl(0, 0%, 13%);


### PR DESCRIPTION
Some color fine tuning to increase contrast for matching the WCAG AA guideline.
https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast?utm_source=devtools&utm_medium=a11y-panel-checks-color-contrast

The difference is barely visible, especially in the light theme. Colors are a tot brighter in the dark theme.

Before:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/df41b44c-97b9-4ab2-b98b-1bab77f1543b)

After:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/8bb79e64-0aab-4d6d-8cd3-c64f39d45edc)

Before:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/ad96bb8f-ef60-40f8-b4e7-b4bf84b8d71f)

After:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/528da37b-7db2-46b6-8a7c-99818413fada)


Before:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/7252a7b7-873c-4431-b78d-ef8595dc02cf)

After:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/3697a1ac-e90b-4706-8982-9b5cbe55a344)

Before:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/c1cdb1f5-166c-4968-bc44-d152eed6c034)

After:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/c2bdd49f-4fe9-46ae-9d96-7fae91309628)
