### PR TITLE
Use webp exclusively for event images

### DIFF
--- a/_pages/community.html
+++ b/_pages/community.html
@@ -257,10 +257,7 @@ section: community
     {%- assign events = site.events | reverse %}
     {%- for event in events %}
       <article class="event-card">
-        <picture>
-          <source srcset="/assets{{ event.id }}.webp" type="image/webp">
-          <img src="/assets{{ event.id }}.png" loading="lazy" alt="" />
-        </picture>
+        <img src="/assets{{ event.id }}.webp" alt="">
         <time datetime="{{ event.start_date }}" itemprop="startDate">{{ event.date_text }}</time>
         <time datetime="{{ event.end_date }}" itemprop="endDate"></time>
 


### PR DESCRIPTION
The png images are missing. And webp is so broadly supported that we probably don't need them.