### PR TITLE
Add `htmltest`

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,22 @@
+DirectoryPath: _site
+IgnoreDirectoryMissingTrailingSlash: true
+IgnoreAltEmpty: true
+IgnoreAltMissing: true
+IgnoreURLs:
+# These sites seem to block automated requests
+# Ref: https://github.com/wjdp/htmltest/issues/165
+- ^https?://twitter\.com\b               # all requests result in 400
+- ^https?://t\.co\b                      # all requests result in 400
+- ^https?://(www\.)?reddit\.com\b        # all requests result in 403
+- ^https?://(www\.)?linkedin\.com\b      # all requests result in 999
+- ^https://us6\.campaign-archive\.com\b  # all requests result in 404
+- ^https://cdn\.pbrd\.co\b               # all requests result in 403
+- ^https://software\.opensuse\.org\b     # all requests result in 400
+- ^https://(www\.)?youtube\.com\b        # all requests result in 404
+
+# Skip archive.org links to avoid unnecessary requests.
+# Archive links should usually exists, but requests are heavy.
+- ^https://web\.archive\.org\b
+
+# GitHub can shut down due to too many requests, but usually works (might need to fill the cache in multiple steps)
+# - ^https?://github\.com\b

--- a/_includes/pages/sponsors/table.html
+++ b/_includes/pages/sponsors/table.html
@@ -13,7 +13,7 @@
       <tr class="{{sponsor_class}}">
         <th class="name" scope="row">
           {%- if sp.url %}
-            <a href="{{sp.url}}" rel="sponsored nofollow">
+            <a href="{{sp.url}}" rel="sponsored nofollow" data-proofer-ignore>
           {%- endif %}
               {%- if sp.logo %}
                 <img src="/assets/{{ sp.logo }}" alt="" />

--- a/_pages/sponsors/original-sponsors.html
+++ b/_pages/sponsors/original-sponsors.html
@@ -7,7 +7,7 @@ section: community
 
   <div class="row">
     <div class="col s12 m8">
-      <table class="bordered">
+      <table class="bordered" data-proofer-ignore>
         <thead>
           <th scope="col">Supporter </th>
         </thead>

--- a/_style_guide/components/link-actions.html
+++ b/_style_guide/components/link-actions.html
@@ -10,5 +10,5 @@ description: |
   <a href="https://github.com/crystal-lang/crystal/releases/tag/1.11.1">Changelog</a>
   <a href="https://github.com/crystal-lang/crystal/tree/1.11.1">Source</a>
   <a href="https://example.com/">Nondescript Link</a>
-  <a href="#"><img src="/assets/install/linux.svg" alt=""> Linux</a>
+  <a href="#top"><img src="/assets/install/linux.svg" alt=""> Linux</a>
 </div>

--- a/_style_guide/components/link-item.html
+++ b/_style_guide/components/link-item.html
@@ -7,22 +7,22 @@ class: wide
   <h3>News</h3>
 
   <div class="link-item">
-    <a class="link-item__main" href="#">
+    <a class="link-item__main" href="#top">
       {%- include icons/newsletter.svg %}
       Main link
     </a>
   </div>
 
   <div class="link-item">
-    <a class="link-item__main" href="#">
+    <a class="link-item__main" href="#top">
       {%- include icons/rss.svg %}
       Main Link
-    </a> (<a href="#">aux link</a>)
+    </a> (<a href="#top">aux link</a>)
     <p>Lorem ipsum dolor sit amet.</p>
   </div>
 
   <div class="link-item">
-    <a href="#">
+    <a href="#top">
       {%- include icons/announce.svg %}
       Link without highlight
     </a>

--- a/_style_guide/typography/footnotes.md
+++ b/_style_guide/typography/footnotes.md
@@ -9,4 +9,4 @@ Lorem ipsum dolor sit amet consectetur adipisicing elit.[^foo] Quod labore susci
 Lorem ipsum dolor sit amet consectetur, adipisicing elit. Quia quos autem veniam libero![^foo] Deleniti nemo quas optio voluptas voluptatibus sint ratione. Id vel error quia ipsam sit saepe hic at amet excepturi ea. Voluptas sunt ratione consequatur optio porro eaque nam quod ex illum modi id animi fugiat vero explicabo illo officiis assumenda nulla rerum, dignissimos sed dicta pariatur quis eum. Beatae ea cumque alias ducimus quos maxime sed, modi illum at repellendus, ex deleniti nesciunt tempore placeat in accusantium!
 
 [^foo]: Lorem ipsum dolor, sit amet consectetur adipisicing elit. Amet voluptas dicta dolor.
-[^bar]: Voluptas sunt ratione consequatur optio [porro eaque](#) nam quod ex illum modi.
+[^bar]: Voluptas sunt ratione consequatur optio [porro eaque](#top) nam quod ex illum modi.

--- a/devenv.nix
+++ b/devenv.nix
@@ -7,6 +7,10 @@
   # `encode': "\\xC3" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
   env.RUBYOPT = "-Eutf-8";
 
+  packages = (with pkgs; [
+    htmltest
+  ]);
+
   processes.serve.exec = "make serve";
 
   enterShell = ''


### PR DESCRIPTION
https://github.com/wjdp/htmltest is a good replacement for htmlproofer. The latter is not completely unusable, but especially the CLI is not very stable. And some things are not easy to configure. It's primarily build as a Ruby library and the CLI is a bit neglected.
Htmltest is kind of an evolution on top of htmlproofer with a more usable configuration and overall easier to use, while similar in functionality. And it's also a lot faster.

This patch adds `htmltest` to devenv and defines the `htmltest` configuration.
There are also two additional changes to make the link checker succeed:
* Sponsor links are entirely ignored. I think that's fine. Sponsors should be responsible for healthy links. We just put down a link to whatever they tell us to link to.
* In the style guide there were some more blank links which were not covered by #632.

The next step would be to use `htmltest` in CI with #598.