### PR TITLE
Fix broken links to github.com

### DIFF
--- a/_pages/team.md
+++ b/_pages/team.md
@@ -120,7 +120,7 @@ Besides those that are explicitly named, this is a call out to
 [hundreds more contributors](https://github.com/crystal-lang/crystal/graphs/contributors)
 who put their work into the project.
 
-If you want to become a contributor, see our [Contributing Instructions](https://github.com/crystal-lang/crystal/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/crystal-lang/crystal/blob/master/CODE_OF_CONDUCT.m).
+If you want to become a contributor, see our [Contributing Instructions](https://github.com/crystal-lang/crystal/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/crystal-lang/crystal/blob/master/CODE_OF_CONDUCT.md).
   </aside>
   <div>
     <img src="https://opencollective.com/crystal-lang/contributors.svg?width=960" alt="">

--- a/_posts/2013-07-13-null-pointer-exception.md
+++ b/_posts/2013-07-13-null-pointer-exception.md
@@ -169,6 +169,5 @@ falsy values are `nil` and `false`, Crystal knows that `line` can't be nil insid
 This is both expressive and executes faster, because it's not needed to check for `nil` values at runtime at every method call.
 
 To conclude this post, one last thing left to say is that while porting the Crystal parser from
-Ruby to
-[Crystal](https://github.com/crystal-lang/crystal/blob/dbe4137444592b0cd30df7170f50f2d0abc2cde2/src/compiler/crystal/parser.cr), Crystal refused to compile
+Ruby to Crystal, Crystal refused to compile
 because of a possible null pointer exception. And it was correct. So in a way, Crystal found a bug in itself :-)

--- a/_posts/2013-09-04-happy-birthday-crystal.md
+++ b/_posts/2013-09-04-happy-birthday-crystal.md
@@ -255,7 +255,7 @@ values = Pointer(Int32).malloc(10) # Ask for 10 ints
 ## Regular expressions
 
 Regular expressions are implemented, for now, with C bindings to the PCRE library. Again,
-[Regexp](https://github.com/crystal-lang/crystal/blob/fd6c0238f6e7725d307d4c010d8c860e38a46d72/src/regexp.cr) is entirely written in Crystal.
+`Regexp` is entirely written in Crystal.
 
 ```ruby
 "foobarbaz" =~ /(.+)bar(.+)/ #=> 0

--- a/_posts/2013-09-23-type-inference-part-1.md
+++ b/_posts/2013-09-23-type-inference-part-1.md
@@ -7,7 +7,7 @@ author: bcardiff
 
 Type inference is a feature every programmer should love. It keep the programmer out of specifying types in the code, and is just so nice.
 
-Here we try to explain the basis on how Crystal infers types of a program. Also aim for a little documentation on how to understand the [type_inference](https://github.com/crystal-lang/crystal/blob/fd6c0238f6e7725d307d4c010d8c860e38a46d72/src/compiler/crystal/type_inference.cr).
+Here we try to explain the basis on how Crystal infers types of a program. Also aim for a little documentation on how to understand the type inference.
 
 Like most type inference algorithms, the explanation is guided by the AST. Each AST node will have an associated type which corresponds to the type of the expression.
 

--- a/_posts/2016-12-26-insert-into-shard-values-crystal-db.md
+++ b/_posts/2016-12-26-insert-into-shard-values-crystal-db.md
@@ -44,6 +44,6 @@ We hope this will help build DB tools and shards that work with multiple drivers
 
 * To [@spalladino](https://github.com/spalladino), [@asterite](https://github.com/asterite), [@waj](https://github.com/waj) for reviewing and discussing the code.
 * To [@will](https://github.com/will) for joining the game.
-* To the early adopters [@crisward](https://github.com/crisward), [@raydf](https://github.com/raydf), [@drujensen](https://github.com/drujensen), [@fridgerator](https://github.com/fridgerator), [@tbrand](https://github.com/tbrand) and many others.
+* To the early adopters [@crisward](https://github.com/crisward), ~~[@raydf](https://github.com/raydf)~~, [@drujensen](https://github.com/drujensen), [@fridgerator](https://github.com/fridgerator), [@tbrand](https://github.com/tbrand) and many others.
 
 

--- a/_releases/2016-05-05-crystal-0.16.0-released.md
+++ b/_releases/2016-05-05-crystal-0.16.0-released.md
@@ -208,7 +208,7 @@ remember the correct order and we use descriptive names.
 
 ### More big numbers
 
-[BigFloat](http://crystal-lang.org/api/BigFloat.html) (thanks to [Exilor](https://github.com/Exilor))
+[BigFloat](http://crystal-lang.org/api/BigFloat.html) (thanks to ~~[Exilor](https://github.com/Exilor)~~)
 and [BigRational](http://crystal-lang.org/api/BigRational.html) (thanks to [will](https://github.com/will))
 were added to the standard library, and together with [BigInt](http://crystal-lang.org/api/BigInt.html)
 should be enough for math programs and other use cases.


### PR DESCRIPTION
This is another follow-up on #631. I had skipped github.com at first because it caused to many false positives from rate limiting.
It now works well with #640.

* Some GitHub user accounts have vanished over the years. Links to abandoned user pages are marked as broken.
* On link was actually a typo.
* I'm also removing some link to files from ancient commits. I had originally tried to fix these links in #89 by replacing
non-permalinks to `master` branch by a commit that corresponds to the time of publication. But apparently that didn't always work. For some reason it appears these files didn't even exist on master when they were mentioned in blog posts. Not sure what's going on there, but the links are not that relevant and it doesn't make much sense to dig deeper into this. We can safely drop them. 