### PR TITLE
Apply `liquify` on page title

### DIFF
--- a/_includes/site/page-header.html
+++ b/_includes/site/page-header.html
@@ -1,5 +1,5 @@
 <header>
-  <h1>{{ include.page_title | default: page.page_title | default: page.title }}</h1>
+  <h1>{{ include.page_title | default: page.page_title | default: page.title | liquify }}</h1>
 
   <div class="page-description">
     {{- page.description | markdownify }}

--- a/_layouts/wide.html
+++ b/_layouts/wide.html
@@ -3,7 +3,7 @@ layout: base
 ---
 
 <header>
-  <h1>{{ page.page_title | default: page.title }}</h1>
+  <h1>{{ page.page_title | default: page.title | liquify }}</h1>
 </header>
 
 {{ content }}


### PR DESCRIPTION
Fixup for #636 which added an `include` to a page title.

![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/a10258a4-873a-4ab7-b8fd-89dfca9129aa)
