### PR TITLE
Tune text size for `link-item` description

### DIFF
--- a/_sass/elements/_link-item.scss
+++ b/_sass/elements/_link-item.scss
@@ -24,9 +24,9 @@
   }
 
   p {
-    font-size: 90%;
     line-height: var(--line-height-md);
     color: var(--light-gray);
+    margin-block-start: var(--padding-xxs);
   }
 }
 


### PR DESCRIPTION
Before:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/5f3e4858-1867-4225-beaf-f6b3238edfe2)

After:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/15357090-02ba-4b43-bb1f-9d52f27bfbed)
