### PR TITLE
Fix `<ul>` height on used_in_prod

### DIFF
--- a/_sass/pages/_used-in-prod.scss
+++ b/_sass/pages/_used-in-prod.scss
@@ -44,6 +44,10 @@
       list-style: none;
       padding: 0;
       line-height: var(--line-height-md);
+
+      // FIXME: No idea why this is necessary, but without it the element is a
+      // bit too short and overflows.
+      height: fit-content;
     }
   }
 }


### PR DESCRIPTION
The height is weirdly broken. I have no explanation. But this workaround makes it work 🤷 

![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/96d3f492-0b49-420c-b159-33df67d1970f)
