### PR TITLE
Fix `box-link` to use `::before` pseudo element

### DIFF
--- a/_sass/mixins/_box-link.scss
+++ b/_sass/mixins/_box-link.scss
@@ -1,5 +1,5 @@
 @mixin box-link {
-  &::after {
+  &::before {
     content: "";
     position: absolute;
     top: 0;
@@ -11,7 +11,7 @@
   &:focus {
     outline: none;
 
-    &::after {
+    &::before {
       outline: 0.14rem dotted var(--lighter-gray);
       outline-offset: 0.08em;
     }


### PR DESCRIPTION
`::after` collided with external link.