### PR TITLE
Make `thead` sticky

### DIFF
--- a/_sass/elements/_table.scss
+++ b/_sass/elements/_table.scss
@@ -9,8 +9,14 @@
     width: unset;
   }
 
-  thead tr {
-    background-color: var(--background-secondary);
+  thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+
+    tr {
+      background: var(--background-secondary);
+    }
   }
 
   th {

--- a/_sass/pages/_sponsors.scss
+++ b/_sass/pages/_sponsors.scss
@@ -43,7 +43,6 @@
   }
 
   > thead > tr {
-    background: none;
     > th {
       white-space: nowrap;
       &:not(:first-child) {


### PR DESCRIPTION
This makes the table header stick to the top of the viewport when scrolling down the body.
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/3a511456-2ec1-4e01-b904-e0c0be796b91)
