### PR TITLE
Avoid line break in section nav item

### DIFF
--- a/_sass/components/_breadcrumbs.scss
+++ b/_sass/components/_breadcrumbs.scss
@@ -62,6 +62,7 @@
     > li {
       display: inline;
       margin-inline-end: var(--padding-xs);
+      white-space: nowrap;
     }
   }
 


### PR DESCRIPTION
Before:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/1d0e9f02-aabb-4b5e-ad8d-f4ef75ada2e6)

After:
![grafik](https://github.com/crystal-lang/crystal-website/assets/466378/669ac693-f339-4124-b949-eb255f969890)
