### PR TITLE
Update other sponsors

### DIFF
--- a/_data/others.json
+++ b/_data/others.json
@@ -23,5 +23,12 @@
     "all_time": 301000,
     "currency": "€",
     "since": "Apr 1, 2018"
+  },
+  {
+    "overrides": "Bookyourdata.com",
+    "name": "Bookyourdata.com",
+    "last_payment": 0,
+    "all_time": 425,
+    "since": "Apr 14, 2019"
   }
 ]

--- a/_data/others.json
+++ b/_data/others.json
@@ -23,19 +23,5 @@
     "all_time": 301000,
     "currency": "€",
     "since": "Apr 1, 2018"
-  },
-  {
-    "overrides": "Bookyourdata.com",
-    "name": "Bookyourdata.com",
-    "last_payment": 0,
-    "all_time": 425,
-    "since": "Apr 14, 2019"
-  },
-  {
-    "overrides": "Screen Recorder",
-    "name": "Screen capture",
-    "last_payment": 0,
-    "all_time": 0,
-    "since": "Dec 31, 2222"
   }
 ]

--- a/_data/others.json
+++ b/_data/others.json
@@ -1,10 +1,10 @@
 [
   {
-    "name": "Manas Technology Solutions",
+    "name": "Manas.Tech",
     "url": "https://manas.tech/",
     "logo": "sponsors/manas.png",
-    "last_payment": 12000,
-    "all_time": 505820,
+    "last_payment": 5000,
+    "all_time": 1300000,
     "since": "Jun 19, 2009"
   },
   {
@@ -20,7 +20,7 @@
     "url": "https://www.84codes.com/",
     "logo": "sponsors/84.png",
     "last_payment": 5000,
-    "all_time": 256000,
+    "all_time": 301000,
     "currency": "€",
     "since": "Apr 1, 2018"
   },

--- a/_data/sponsors.csv
+++ b/_data/sponsors.csv
@@ -23,6 +23,7 @@ sponsors/kevin_hovsäter.jpg,Kevin Hovsäter,,$75,$530,"May 22, 2020",75
 ,Jeremy Woertink,,$25,$275,"Mar 30, 2023",25
 ,lowkey,,$10,"$2,610","Jun 12, 2021",10
 ,pitosalas,,$20,$825,"Dec 20, 2017",10
+,Bookyourdata.com,https://www.bookyourdata.com,$10,$735,"Apr 14, 2019",10
 ,Christos Zisopoulos,,$10,$660,"Jun 23, 2016",10
 ,masukomi,http://masukomi.org,$10,$640,"Aug 7, 2016",10
 ,Noriyo Akita,http://hyperneetprogrammer.hatenablog.com/,$10,$615,"Jul 21, 2018",10
@@ -37,7 +38,6 @@ sponsors/kevin_hovsäter.jpg,Kevin Hovsäter,,$75,$530,"May 22, 2020",75
 ,Josh Hollenbeck,,$10,$380,"Dec 19, 2020",10
 ,Lampros Chaidas,,$10,$350,"Mar 29, 2021",10
 ,rigani,https://twitter.com/rigani_c,$10,$310,"Dec 28, 2018",10
-,Bookyourdata.com,https://www.bookyourdata.com,$10,$310,"Aug 10, 2021",10
 ,Bromine0x23,https://twitter.com/bromine0x23,$10,$290,"Feb 27, 2021",10
 ,Alexander Adam,https://github.com/alexanderadam/alexanderadam#-about-me,$10,$290,"Oct 1, 2021",10
 ,Glen A-B,,$10,$275,"May 5, 2020",10

--- a/_data/sponsors.csv
+++ b/_data/sponsors.csv
@@ -1,6 +1,6 @@
 logo,name,url,last_payment,all_time,since,level
-sponsors/manas.png,Manas Technology Solutions,https://manas.tech/,"$12,000","$505,820","Jun 19, 2009",5000
-sponsors/84.png,84 codes,https://www.84codes.com/,"€5,000","€256,000","Apr 1, 2018",5000
+sponsors/manas.png,Manas.Tech,https://manas.tech/,"$5,000","$1,300,000","Jun 19, 2009",5000
+sponsors/84.png,84 codes,https://www.84codes.com/,"€5,000","€301,000","Apr 1, 2018",5000
 sponsors/placeos.png,PlaceOS,https://place.technology/,$250,"$7,000","Jul 26, 2021",250
 sponsors/vulk_cooperative.png,Vulk Cooperative,https://www.vulk.coop,$75,"$5,625","Sep 10, 2020",75
 sponsors/blitline.png,Blitline,https://www.blitline.com,$75,"$4,725","Dec 12, 2018",75
@@ -23,7 +23,6 @@ sponsors/kevin_hovsäter.jpg,Kevin Hovsäter,,$75,$530,"May 22, 2020",75
 ,Jeremy Woertink,,$25,$275,"Mar 30, 2023",25
 ,lowkey,,$10,"$2,610","Jun 12, 2021",10
 ,pitosalas,,$20,$825,"Dec 20, 2017",10
-,Bookyourdata.com,https://www.bookyourdata.com,$10,$735,"Apr 14, 2019",10
 ,Christos Zisopoulos,,$10,$660,"Jun 23, 2016",10
 ,masukomi,http://masukomi.org,$10,$640,"Aug 7, 2016",10
 ,Noriyo Akita,http://hyperneetprogrammer.hatenablog.com/,$10,$615,"Jul 21, 2018",10
@@ -38,6 +37,7 @@ sponsors/kevin_hovsäter.jpg,Kevin Hovsäter,,$75,$530,"May 22, 2020",75
 ,Josh Hollenbeck,,$10,$380,"Dec 19, 2020",10
 ,Lampros Chaidas,,$10,$350,"Mar 29, 2021",10
 ,rigani,https://twitter.com/rigani_c,$10,$310,"Dec 28, 2018",10
+,Bookyourdata.com,https://www.bookyourdata.com,$10,$310,"Aug 10, 2021",10
 ,Bromine0x23,https://twitter.com/bromine0x23,$10,$290,"Feb 27, 2021",10
 ,Alexander Adam,https://github.com/alexanderadam/alexanderadam#-about-me,$10,$290,"Oct 1, 2021",10
 ,Glen A-B,,$10,$275,"May 5, 2020",10
@@ -152,7 +152,7 @@ sponsors/nikola_motor_company.png,Nikola Motor Company,https://nikolamotor.com/,
 ,Tumbler Lock,,$0,"$1,500","Dec 27, 2018",0
 ,Julien Reichardt,,$0,"$1,150","Dec 13, 2018",0
 ,Andrew Lewman,,$0,"$1,050","Aug 6, 2020",0
-,Screen capture,,$0,"$1,000","Nov 19, 2021",0
+,Screen Recorder,,$0,"$1,000","Nov 19, 2021",0
 ,Screen recorder,,$0,"$1,000","Nov 19, 2021",0
 ,ATNOS,,$0,$675,"Dec 11, 2020",0
 ,Triplebyte,,$0,$640,"Dec 28, 2018",0


### PR DESCRIPTION
This PR
- fixes the name of Manas,
- updates the numbers to reflect reality,
- updates the total of 84codes,
- remove old overrides since that's for old sponsors that are now at the bottom of the list.