### PR TITLE
Reduce number of nav menu entries

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -73,8 +73,6 @@ home:
   url: /releases/
 - label: Success stories
   url: /success-stories/
-- label: Used in production
-  url: /used_in_prod/
 - label: Sitemap
   url: /sitemap/
 

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -29,8 +29,6 @@ community:
   url: /community/#events
 - label: Used in production
   url: /used_in_prod/
-- label: Newsletter
-  url: /newsletter/
 - label: Forum
   url: https://forum.crystal-lang.org/
 - label: Governance

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -29,8 +29,6 @@ community:
   url: /community/#events
 - label: Used in production
   url: /used_in_prod/
-- label: Forum
-  url: https://forum.crystal-lang.org/
 - label: Governance
   url: /community/governance/
 


### PR DESCRIPTION
* *Newsletter* is getting a link in the form (https://github.com/crystal-lang/crystal-website/pull/724)
* *Forum* is already linked twice: icon in the top right corner, and *help* menu in the footer
* *Used in production* was duplicated in both *home* and *community* navs, removed it from the former

This brings the number of menu items down to five which is a more reasonable amount for efficient navigation.
We could reduce the number in the *Documentation* menu as well, but I'm not sure where to cut. I guess it's fine.