### PR TITLE
Sort sponsors by amount instead of level

### DIFF
--- a/_data/sponsors.csv
+++ b/_data/sponsors.csv
@@ -8,8 +8,8 @@ sponsors/prestodoctor.png,PrestoDoctor,https://prestodoctor.com,$75,"$4,500","De
 sponsors/ryan_maki.png,Ryan Maki,,$75,"$3,000","Dec 2, 2020",75
 sponsors/concentric.png,Concentric,https://concentric.health,$75,"$1,050","Feb 2, 2023",75
 sponsors/kevin_hovsäter.jpg,Kevin Hovsäter,,$75,$605,"May 22, 2020",75
-,Thomas Peter Berntsen,https://twitter.com/tpberntsen,$25,"$4,375","Sep 20, 2015",25
 ,isaacsloan,https://isaacsloan.com,$36,"$2,506","Mar 24, 2016",25
+,Thomas Peter Berntsen,https://twitter.com/tpberntsen,$25,"$4,375","Sep 20, 2015",25
 ,Frank O'Hara,,$25,"$1,900","Aug 16, 2015",25
 ,Jerome Gravel-Niquet,http://www.fly.io,$25,"$1,775","Jan 28, 2016",25
 ,Raels Koder,,$25,"$1,325","Oct 30, 2019",25
@@ -22,8 +22,11 @@ sponsors/kevin_hovsäter.jpg,Kevin Hovsäter,,$75,$605,"May 22, 2020",75
 ,Casinoonlineaams.com,https://www.casinoonlineaams.com,$25,$850,"May 26, 2021",25
 ,Jeremy Woertink,,$25,$300,"Mar 30, 2023",25
 ,Eddy Luten,https://luten.dev/,$25,$105,"Jun 18, 2023",25
-,lowkey,,$10,"$2,610","Jun 12, 2021",10
 ,pitosalas,,$20,$825,"Dec 20, 2017",10
+,Daniel Salazar,,$20,$50,"Oct 15, 2023",10
+,Werner Stein,,$15,$470,"Jan 24, 2021",10
+,Andrey A. Konovalov,http://sysadminblog.ru,$14,$428,"Mar 6, 2018",10
+,lowkey,,$10,"$2,610","Jun 12, 2021",10
 ,Bookyourdata.com,https://www.bookyourdata.com,$10,$745,"Apr 14, 2019",10
 ,Christos Zisopoulos,,$10,$660,"Jun 23, 2016",10
 ,masukomi,http://masukomi.org,$10,$640,"Aug 7, 2016",10
@@ -32,10 +35,8 @@ sponsors/kevin_hovsäter.jpg,Kevin Hovsäter,,$75,$605,"May 22, 2020",75
 ,Greg Walker,http://learnmeabitcoin.com,$10,$550,"Nov 21, 2016",10
 ,dtakahas,https://github.com/dtakahas,$10,$540,"Jun 6, 2017",10
 ,infinitary,https://infinitary.org,$10,$505,"Jun 11, 2018",10
-,Werner Stein,,$15,$470,"Jan 24, 2021",10
 ,marksiemers,https://github.com/marksiemers,$10,$460,"Aug 29, 2017",10
 ,grioja,https://github.com/grioja,$10,$450,"Mar 31, 2018",10
-,Andrey A. Konovalov,http://sysadminblog.ru,$14,$428,"Mar 6, 2018",10
 ,Josh Hollenbeck,,$10,$390,"Dec 19, 2020",10
 ,Lampros Chaidas,,$10,$360,"Mar 29, 2021",10
 ,rigani,https://twitter.com/rigani_c,$10,$310,"Dec 28, 2018",10
@@ -55,7 +56,6 @@ sponsors/kevin_hovsäter.jpg,Kevin Hovsäter,,$75,$605,"May 22, 2020",75
 ,EaseUS Germany,https://www.easeus.de/,$10,$90,"Jun 28, 2023",10
 ,EaseUS RecExperts,https://recorder.easeus.com,$10,$90,"Jun 28, 2023",10
 ,Buy Instagram Followers Twicsy,https://twicsy.com/buy-instagram-followers,$10,$90,"Jul 7, 2023",10
-,Daniel Salazar,,$20,$50,"Oct 15, 2023",10
 ,LightNode,https://www.lightnode.com,$10,$40,"Dec 7, 2023",10
 ,LightCDN,https://www.lightcdn.com,$10,$40,"Dec 14, 2023",10
 ,$200 no deposit bonus 200 free spins real money,https://www.outlookindia.com/outlook-spotlight/200-dollar-no-deposit-news-338245,$10,$20,"Jan 17, 2024",10

--- a/scripts/merge.cr
+++ b/scripts/merge.cr
@@ -41,7 +41,7 @@ overrides.each do |sponsor|
   end
 end
 
-all_sponsors.sort_by! { |s| {-level(s), -s.all_time, s.since, s.name} }
+all_sponsors.sort_by! { |s| {-s.last_payment, -s.all_time, s.since, s.name} }
 
 File.open("#{__DIR__}/../_data/sponsors.csv", "w") do |file|
   CSV.build(file) do |csv|


### PR DESCRIPTION
The page list sponsors as ordered by amount, but in fact they are ordered by level. This is unfair to those putting a bit (or a lot) more than others at the same level. This PR fixes that.