### PR TITLE
Update sponsors with current legacy rules

### DIFF
--- a/_data/sponsor_logos_s.csv
+++ b/_data/sponsor_logos_s.csv
@@ -1,2 +1,3 @@
 logo,name,url,last_payment,all_time,since,level
 sponsors/woa.png,Works on Arm,https://developer.arm.com/solutions/infrastructure/works-on-arm,$500,$0,"Jul 22, 2021",500
+sponsors/placeos.png,PlaceOS,https://place.technology/,$250,"$7,250","Jul 26, 2021",250


### PR DESCRIPTION
This is a followup to #740 because I forgot to regenerate sponsors data after the latest changes in that PR.