### PR TITLE
Remove Nikola logo and link from sponsors list

### DIFF
--- a/_data/others.json
+++ b/_data/others.json
@@ -9,8 +9,6 @@
   },
   {
     "name": "Nikola Motor Company",
-    "url": "https://nikolamotor.com/",
-    "logo": "sponsors/nikola.svg",
     "last_payment": 0,
     "all_time": 165000,
     "since": "Mar 1, 2020"

--- a/_data/sponsors.csv
+++ b/_data/sponsors.csv
@@ -144,7 +144,7 @@ sponsors/kevin_hovsäter.jpg,Kevin Hovsäter,,$75,$605,"May 22, 2020",75
 ,Kendall Park,,$1,$37,"Nov 22, 2018",1
 ,Sergey Kojin,,$1,$26,"Oct 7, 2019",1
 ,GOKI MORI,,$1,$16,"Mar 16, 2023",1
-sponsors/nikola.svg,Nikola Motor Company,https://nikolamotor.com/,$0,"$165,000","Mar 1, 2020",0
+,Nikola Motor Company,,$0,"$165,000","Mar 1, 2020",0
 ,Dutchie,,$0,"$3,450","Nov 23, 2020",0
 ,Jonathan Siegel,,$0,"$1,950","Sep 12, 2022",0
 ,Tumbler Lock,,$0,"$1,500","Dec 27, 2018",0


### PR DESCRIPTION
Nikola still showed a logo and link on the sponsor page because it was hard coded in `others.json`.