### PR TITLE
Remove broken nightly download links for Windows

### DIFF
--- a/_data/packages-nightly.yaml
+++ b/_data/packages-nightly.yaml
@@ -65,19 +65,19 @@
 
 ### Windows
 
-- type: crystal
-  os: Windows
-  arch: [x86_64]
-  title: Installer (`.exe`)
-  instructions_href: /install/on_windows/
-  # archive_href: https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal-installer.zip
+# - type: crystal
+#   os: Windows
+#   arch: [x86_64]
+#   title: Installer (`.exe`)
+#   instructions_href: /install/on_windows/
+#   archive_href: https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal-installer.zip
 
-- type: crystal
-  os: Windows
-  arch: [x86_64]
-  title: Portable Archive (`.zip`)
-  instructions_href: /install/on_windows/
-  # archive_href: https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal.zip
+# - type: crystal
+#   os: Windows
+#   arch: [x86_64]
+#   title: Portable Archive (`.zip`)
+#   instructions_href: /install/on_windows/
+#   archive_href: https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal.zip
 
 - type: community
   os: Windows

--- a/_data/packages-nightly.yaml
+++ b/_data/packages-nightly.yaml
@@ -70,14 +70,14 @@
   arch: [x86_64]
   title: Installer (`.exe`)
   instructions_href: /install/on_windows/
-  archive_href: https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal-installer.zip
+  # archive_href: https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal-installer.zip
 
 - type: crystal
   os: Windows
   arch: [x86_64]
   title: Portable Archive (`.zip`)
   instructions_href: /install/on_windows/
-  archive_href: https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal.zip
+  # archive_href: https://nightly.link/crystal-lang/crystal/workflows/win/master/crystal.zip
 
 - type: community
   os: Windows


### PR DESCRIPTION
The nightly downloads for Windows currently don't work.

We should enable them once https://github.com/crystal-lang/crystal/issues/14256 is resolved.