### PR TITLE
Fix platform logos in dark mode

### DIFF
--- a/_sass/mixins/_link-with-icon.scss
+++ b/_sass/mixins/_link-with-icon.scss
@@ -31,8 +31,10 @@
     mask: var(--link-icon) center / contain no-repeat;
   }
 
-  &:not(:hover) > img {
-    filter: #{"grayscale()"};
+  @media not (prefers-color-scheme: dark) {
+    &:not(:hover) > img {
+      filter: #{"grayscale()"};
+    }
   }
 }
 

--- a/_sass/mixins/_link-with-icon.scss
+++ b/_sass/mixins/_link-with-icon.scss
@@ -30,12 +30,6 @@
     -webkit-mask: var(--link-icon) center / contain no-repeat;
     mask: var(--link-icon) center / contain no-repeat;
   }
-
-  @media not (prefers-color-scheme: dark) {
-    &:not(:hover) > img {
-      filter: #{"grayscale()"};
-    }
-  }
 }
 
 @mixin link-with-colored-icon-base {


### PR DESCRIPTION
In dark mode, due to the platform logos being in img elements, they do not inherit the text color.

![image](https://github.com/crystal-lang/crystal-website/assets/18014039/7e26ce12-0367-460e-8b25-a8b2092ff0c6)

This PR fixes it in a hacky(?) way, by inverting their color in dark mode

![image](https://github.com/crystal-lang/crystal-website/assets/18014039/23cc519b-5108-49bb-be54-93f042be6bf7)
