### PR TITLE
Refactor main layout centering and margins

### DIFF
--- a/_includes/posts/more_articles.html
+++ b/_includes/posts/more_articles.html
@@ -1,6 +1,6 @@
 {% assign numposts = include.posts | size %}
 {% if numposts > 5 %}
-<hr class="full-width" />
+<hr class="full-width-rule" />
 
 <section>
   <h1>More articles</h1>

--- a/_sass/_utilities.scss
+++ b/_sass/_utilities.scss
@@ -21,12 +21,6 @@
   --link-hover-color: var(--lighter-text);
 }
 
-.full-width {
-  width: 100vw;
-  transform: translateX(-50%);
-  margin-left: 50%;
-}
-
 .pill {
   @extend .pill-form;
   font-size: font-size(small);

--- a/_sass/_utilities.scss
+++ b/_sass/_utilities.scss
@@ -23,7 +23,6 @@
 
 .full-width {
   width: 100vw;
-  width: 100cqw;
   transform: translateX(-50%);
   margin-left: 50%;
 }

--- a/_sass/base/_layout.scss
+++ b/_sass/base/_layout.scss
@@ -18,11 +18,7 @@ body {
   min-height: 100vh;
   background-color: var(--background-main);
 
-  --main-width: min(100cqw - 3rem, var(--container-max, 120ch));
-
-  // This is a workaround for 100vw not accounting for the width of the scrollbar gutter
-  // https://www.smashingmagazine.com/2023/12/new-css-viewport-units-not-solve-classic-scrollbar-problem/#avoiding-the-classic-scrollbar-problem
-  container-type: inline-size;
+  --main-width: min(100vw - 3rem, var(--container-max, 120ch));
   overflow: auto;
 }
 

--- a/_sass/base/_layout.scss
+++ b/_sass/base/_layout.scss
@@ -18,13 +18,7 @@ body {
   min-height: 100vh;
   background-color: var(--background-main);
 
-  --main-width: min(100vw - 3rem, var(--container-max, 120ch));
   overflow: auto;
-}
-
-body > * {
-  width: var(--main-width);
-  margin-inline: auto;
 }
 
 body > header {
@@ -40,6 +34,9 @@ body > .edit-on-github {
 
 body > main {
   @include blockflow(var(--block-flow-lg));
+  margin-inline: 1.5rem;
+  align-self: center;
+  max-width: var(--container-max, 120ch);
 
   margin-block-end: var(--block-flow-lg);
 

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -2,7 +2,6 @@
   @include external-links;
 
   width: 100vw;
-  width: 100cqw;
   text-align: center;
   padding: var(--padding-sm);
   background-color: var(--background-tertiary);
@@ -66,7 +65,7 @@ footer {
   gap: var(--block-flow-md) var(--block-flow-sm);
 
   --container-max: 130ch;
-  --main-width: min(100cqw - 3rem, var(--container-max, 110ch));
+  --main-width: min(100vw - 3rem, var(--container-max, 110ch));
 
   .link-items {
     > h3 {

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -1,7 +1,7 @@
 .edit-on-github {
   @include external-links;
 
-  width: 100vw;
+  max-width: none;
   text-align: center;
   padding: var(--padding-sm);
   background-color: var(--background-tertiary);
@@ -18,34 +18,23 @@
 }
 
 footer {
+  --container-max: 130ch;
   display: flex;
   flex-direction: column;
   gap: var(--block-flow-md);
+  align-items: center;
+  padding-inline: 1.5rem;
 
   padding-block: var(--block-flow-sm);
   --link-color: var(--light-text);
   --link-hover-color: var(--lighter-text);
 
-  position: relative;
-
-  &::after {
-    content: "";
-
-    @extend .full-width;
-
-    display: block;
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    top: 0;
-    right: 0;
-
-    border-top: 1.5px solid var(--border-color);
-    background-color: var(--background-secondary);
-  }
+  border-top: 1.5px solid var(--border-color);
+  background-color: var(--background-secondary);
 
   > * {
-    z-index: 1;
+    width: 100%;
+    max-width: var(--container-max, 120ch);
     line-height: var(--line-height-md);
     font-size: font-size(small);
   }
@@ -63,9 +52,6 @@ footer {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(max(9em, 17%), 1fr));
   gap: var(--block-flow-md) var(--block-flow-sm);
-
-  --container-max: 130ch;
-  --main-width: min(100vw - 3rem, var(--container-max, 110ch));
 
   .link-items {
     > h3 {
@@ -194,8 +180,6 @@ nav.footer-section {
 
   &::before {
     content: "";
-
-    @extend .full-width;
 
     display: block;
     position: absolute;

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -6,7 +6,6 @@ body > header {
   --link-hover-color: var(--primary-text);
   padding: var(--padding-xs);
 
-  width: 100vw;
   display: grid;
   grid-template-columns:
     minmax(

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -7,13 +7,12 @@ body > header {
   padding: var(--padding-xs);
 
   width: 100vw;
-  width: 100cqw;
   display: grid;
   grid-template-columns:
     minmax(
       min-content,
       calc(
-        (100cqw - var(--main-width)) / 2 - var(--padding-xs) - var(--padding-sm)
+        (100vw - var(--main-width)) / 2 - var(--padding-xs) - var(--padding-sm)
       )
     )
     minmax(min-content, var(--main-width)) auto max-content;

--- a/_sass/pages/_conference.scss
+++ b/_sass/pages/_conference.scss
@@ -8,7 +8,6 @@
     background-color: white;
     z-index: 100;
     width: 100vw;
-    width: 100cqw;
     padding-left: 15vw;
     margin-left: -15vw;
     margin-bottom: 30px;

--- a/_sass/pages/_conference.scss
+++ b/_sass/pages/_conference.scss
@@ -7,7 +7,6 @@
     margin: 0;
     background-color: white;
     z-index: 100;
-    width: 100vw;
     padding-left: 15vw;
     margin-left: -15vw;
     margin-bottom: 30px;

--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -1,7 +1,7 @@
 .layout--home > header {
   color-scheme: dark;
   grid-template-columns:
-    1fr minmax(min-content, var(--main-width)) minmax(0, min-content)
+    1fr minmax(min-content, var(--container-max, 120ch)) minmax(0, min-content)
     1fr;
   grid-template-areas:
     ". main    util    util"

--- a/_sass/utilities/_full-width-rule.scss
+++ b/_sass/utilities/_full-width-rule.scss
@@ -1,5 +1,4 @@
 .full-width-rule {
-  @extend .full-width;
   display: grid;
   grid-template: "container";
   place-items: center;
@@ -8,8 +7,9 @@
   &:before {
     content: "";
     display: block;
-    width: 100vw;
     position: absolute;
+    inset-inline: 0;
+
     border-block-end: 0.16ch solid var(--border-color);
   }
 }

--- a/_sass/utilities/_full-width-rule.scss
+++ b/_sass/utilities/_full-width-rule.scss
@@ -1,7 +1,6 @@
 .full-width-rule {
   display: grid;
-  grid-template: "container";
-  place-items: center;
+  justify-items: center;
   font-size: 1rem;
 
   &:before {
@@ -11,5 +10,12 @@
     inset-inline: 0;
 
     border-block-end: 0.16ch solid var(--border-color);
+  }
+
+  // FIXME: This workaround with hard-coded margin is for WebKit which apparently
+  // fails to honor `align-items: center` and places `:before` at the top.
+  &:has(.hex):before {
+    transform: translateY(-50%);
+    margin-top: 1.25em;
   }
 }

--- a/_sass/utilities/_full-width-rule.scss
+++ b/_sass/utilities/_full-width-rule.scss
@@ -9,7 +9,6 @@
     content: "";
     display: block;
     width: 100vw;
-    width: 100cqw;
     position: absolute;
     border-block-end: 0.16ch solid var(--border-color);
   }


### PR DESCRIPTION
This patch reverts the workaround from #716 and instead refactors the entire centering layout and margin. It's less complicated now.

Resolves #765 (hopefully)