### PR TITLE
Fix no line break between manas label and logo

### DIFF
--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -190,6 +190,11 @@ nav.footer-section {
     margin-block-start: calc(-1 * var(--block-flow-sm));
   }
 
+  a[href="https://manas.tech"]
+  {
+    white-space: nowrap;
+  }
+
   // FIXME: The following two rules are a workaround for WebKit which would
   // otherwise not stretch the paragraphs wide enough so that the second one
   // would be rendered with a line break despite being enough space available.


### PR DESCRIPTION
This is a follow-up to #771 to ensure proper layout when the text width is actually two narrow (on a small viewport).