### PR TITLE
Fix max width for repeat grid layout columns on ultra small viewports

### DIFF
--- a/_sass/components/_book-authors.scss
+++ b/_sass/components/_book-authors.scss
@@ -1,6 +1,6 @@
 .book-authors {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(20em, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 20em), 1fr));
 
   column-gap: var(--padding-md);
   row-gap: var(--padding-lg);

--- a/_sass/components/_featured-posts.scss
+++ b/_sass/components/_featured-posts.scss
@@ -3,7 +3,7 @@
   display: grid;
   grid-template-columns: repeat(
     auto-fit,
-    minmax(min(100%, var(--min, 25em)), 1fr)
+    minmax(min(100%, min(100%, var(--min, 25em))), 1fr)
   );
 
   gap: var(--block-flow-sm);

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -50,7 +50,7 @@ footer {
   @extend .ui-link;
 
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(max(9em, 17%), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(clamp(17%, 9em, 100%), 1fr));
   gap: var(--block-flow-md) var(--block-flow-sm);
 
   .link-items {

--- a/_sass/components/_topics.scss
+++ b/_sass/components/_topics.scss
@@ -1,6 +1,6 @@
 .topics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(14em, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 14em), 1fr));
 
   column-gap: var(--padding-md);
   row-gap: var(--padding-lg);

--- a/_sass/pages/_blog.scss
+++ b/_sass/pages/_blog.scss
@@ -54,14 +54,16 @@
 
   @media (max-width: 49em) {
     grid-template-columns: 1fr;
-
     > .releases-info {
-      flex-direction: row;
       order: -1;
 
-      > .hex {
-        margin-bottom: 0;
-        margin-right: var(--padding-sm);
+      @media (min-width: 22em) {
+        flex-direction: row;
+
+        > .hex {
+          margin-bottom: 0;
+          margin-right: var(--padding-sm);
+        }
       }
     }
   }

--- a/_sass/pages/_used-in-prod.scss
+++ b/_sass/pages/_used-in-prod.scss
@@ -1,6 +1,6 @@
 .used-in-production {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(25em, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 25em), 1fr));
   gap: var(--block-flow-md);
 
   > section {


### PR DESCRIPTION
If the viewport is ultra small, the auto fit column widths may exceed the viewport widths, so we need a limitation to 100%.