### PR TITLE
Fix typo in relase post for 1.12.0

### DIFF
--- a/_releases/2024-04-09-1.12.0-released.md
+++ b/_releases/2024-04-09-1.12.0-released.md
@@ -29,7 +29,7 @@ _Thanks [@HertzDevil]_
 
 ### Process termination handler
 
-[`Process.on_terminate`](https://crystal-lang.org/api/1.12.0/Process.html#on_terminate%28%26handler%3AProcess%3A%3AExitReason-%3E%29%3ANil-class-method) replaces [`Process.on_interrupt`](https://crystal-lang.org/api/1.12.0/Process.html#on_interrupt(%26handler%3A-%3E)%3ANil-class-method) as a more potable and portable API for responding to termination requests ([#13694](https://github.com/crystal-lang/crystal/pull/13694)).
+[`Process.on_terminate`](https://crystal-lang.org/api/1.12.0/Process.html#on_terminate%28%26handler%3AProcess%3A%3AExitReason-%3E%29%3ANil-class-method) replaces [`Process.on_interrupt`](https://crystal-lang.org/api/1.12.0/Process.html#on_interrupt(%26handler%3A-%3E)%3ANil-class-method) as a more potent and portable API for responding to termination requests ([#13694](https://github.com/crystal-lang/crystal/pull/13694)).
 All current uses of `on_interrupt` can be replaced by `on_terminate` with the effect of responding to more termination triggers.
 
 | Method         | Unix                             | Windows                                                                                                                                                 |


### PR DESCRIPTION
`s/potable/potent/`