### PR TITLE
Disable styles that break rendering on Safari iPhone

### DIFF
--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -48,8 +48,11 @@
 
     background-image: url(/assets/home/pattern.svg);
     background-repeat: no-repeat;
-    background-size: clamp(30vw, max(80rem, 50vw), 250vw) auto;
-    background-position: clamp(-15vw, -40rem + 50vw, 0px) top;
+
+    // FIXME: Disabled as a workaround to fix rendering in Safari on iPhone
+    // See https://github.com/crystal-lang/crystal-website/issues/758#issuecomment-2053688906
+    // background-size: clamp(30vw, max(80rem, 50vw), 250vw) auto;
+    // background-position: clamp(-15vw, -40rem + 50vw, 0px) top;
   }
 
   > * {


### PR DESCRIPTION
This is a quick fix to enable rendering on iPhone Safari. It degrades visuals on all platforms (the pattern doesn't span the entire widht on large viewports), but this is acceptable as a temporary fix.
We'll need to investigate if we can find other solutions or make this one selective to only affected browsers.

See https://github.com/crystal-lang/crystal-website/issues/758#issuecomment-2053688906