### PR TITLE
Fix: add back Google Analytics reporting

### DIFF
--- a/_layouts/skeleton.html
+++ b/_layouts/skeleton.html
@@ -52,5 +52,6 @@ layout: none
 
   <body class="layout--{{ page.layout }}">
     {{- content }}
+    {% include site/google_analytics.html %}
   </body>
 </html>


### PR DESCRIPTION
We've dropped it in #414, probably by mistake