### PR TITLE
Reduce grace time to 2 months

### DIFF
--- a/scripts/opencollective.cr
+++ b/scripts/opencollective.cr
@@ -46,7 +46,7 @@ team = "crystal-lang"
 opencollective = OpenCollective::API.new(team)
 sponsors = SponsorsBuilder.new
 
-dateOfGrace = Time.utc - 3.months
+dateOfGrace = Time.utc - 2.months
 opencollective.members.each do |member|
   next unless member.role == "BACKER"
 
@@ -58,7 +58,7 @@ opencollective.members.each do |member|
   url = member.website || member.twitter || member.github
   logo = member.image
 
-  # We consider a member as not paying anything if it's inactive or it haven't sponsored in the last 3 months
+  # We consider a member as not paying anything if it's inactive or it haven't sponsored in the last 2 months
   if member.isActive && member.lastTransactionAt > dateOfGrace
     amount = member.lastTransactionAmount
   else


### PR DESCRIPTION
Sometimes payments fail, and a sponsor might lose its level. In order to avoid flukes to affect our beloved sponsors, we added a "grace time": only after certain period of not registering a payment the sponsor misses its status. This is also good for our CI setting: if a sponsor makes a one-time payment, and something fails on our side and we take some time to repair it, the sponsor gets enough time (more than a month) to enjoy the status.

However, currently the grace time is too long: 3 months, meaning that a one-timer gets 3 months of exposure in our site. I suggest lowering it to 2.