### PR TITLE
Add `.devenv` to exclude paths

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,6 +79,7 @@ social:
 exclude:
 - "*.nix"
 - "devenv*"
+- ".devenv/"
 - docker-compose.yml
 - docker-compose.*.yml
 - Gemfile


### PR DESCRIPTION
`.devenv` folder is used by devenv and should not be part of the site output.