### PR TITLE
[CI] Change `update-sponsors` workflow to run weekly every Tuesday

### DIFF
--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -2,7 +2,7 @@ name: Update Sponsors
 
 on:
   schedule:
-    - cron:  '0 9 1,8,15,23 * *'
+    - cron:  '0 9 * * 2'
 
   workflow_dispatch:
 


### PR DESCRIPTION
I think it's better to have the workflow run every week than on fixed days of the month which leads to an irregular schedule. I'm chosing Tuesday because today is a Tuesday. And it seems convenient.