### PR TITLE
Remove contrast filter in top-sponsor logos

### DIFF
--- a/_sass/components/_top-sponsors.scss
+++ b/_sass/components/_top-sponsors.scss
@@ -8,14 +8,17 @@
   @extend .ui-link;
 
   --top-sponsors-icon-width: 11ch;
-  --top-sponsors-icon-filter: #{"contrast(2) grayscale()"};
+  --top-sponsors-icon-filter: #{"grayscale()"};
 
   --link-color: var(--primary-text);
   --link-hover-color: var(--light-text);
 
+  @media (prefers-color-scheme: dark) {
+    --top-sponsors-icon-filter: #{"invert() contrast(0.78) grayscale()"};
+  }
+
   &--s {
     --top-sponsors-icon-width: 7ch;
-    --top-sponsors-icon-filter: #{"contrast(0.4) grayscale()"};
     --link-color: var(--lighter-text);
     font-size: font-size(xsmall);
   }


### PR DESCRIPTION
I don't recall the exact purpose of the contrast filter, but it really didn't have much effect in light mode, and a rather unpleasant effect in dark mode.
So the contrast filters are dropped, but instead I'm adding an updated filter for dark mode which includes an `invert()` to better align the lightness for dark mode. The contrast in dark mode matches the background color of the image to the background color of the page, to achieve a transparency effect as in light mode.

### Dark

**Before**

![grafik](https://github.com/user-attachments/assets/19c0325e-2016-411f-8c17-67a15083a3e4)


**After**
![grafik](https://github.com/user-attachments/assets/be895dff-9085-4664-a8c2-b51975cba5d6)

### Light

**Before**

![grafik](https://github.com/user-attachments/assets/faf79075-2b57-4f7d-929c-2aacdad052f3)


**After**

![grafik](https://github.com/user-attachments/assets/2a34f020-2538-4467-83a9-36d0f858c5ea)
