### PR TITLE
Drop filter on version badges

### DIFF
--- a/_sass/pages/_install.scss
+++ b/_sass/pages/_install.scss
@@ -121,16 +121,6 @@ img.version-badge {
   display: inline-block;
   vertical-align: sub;
   transition: all 0.25s;
-
-  @media not (prefers-color-scheme: dark) {
-    filter: invert(49%) saturate(8000%) brightness(120%) contrast(500%)
-      sepia(40%) saturate(85%);
-
-    :any-link:hover > & {
-      filter: invert(49%) saturate(8000%) brightness(120%) contrast(500%)
-        sepia(40%) saturate(85%) brightness(75%);
-    }
-  }
 }
 
 @media (max-width: 50em) {


### PR DESCRIPTION
The filter is purely cosmetical, but resulted in bad legibility in some browser renderings.

It's a bit of dark wizardry in an attempt to bend the colors and constrast without having to rewrite the SVG content (which is not easily possible).

Resolves #859 