### PR TITLE
Turn `alert` popup for XML request failure into console error

### DIFF
--- a/assets/js/_viewer.js
+++ b/assets/js/_viewer.js
@@ -336,7 +336,7 @@ function Viewer3D(container) {
         computeNormals();
         animate();
       } else {
-        alert("xml request error: " + _req.statusText);
+        console.error("xml request error: " + _req.status + " (" + _req.statusText + ")");
       }
     }
   }
@@ -347,7 +347,7 @@ function Viewer3D(container) {
     } else if (window.ActiveXObject) {
       return new ActiveXObject("Microsoft.XMLHTTP");
     }
-    alert("Can't find XML Http Request object!");
+    console.error("Can't find XML Http Request object!");
   }
 
   function mouseDownHandler(event) {


### PR DESCRIPTION
In case the geometry data fails to load (for whatever reason), the alert popup provides no meaningful information for users.
Turning it into a console error reduces the popup inconvenience.

via https://matrix.to/#/!DCnOFYRfeFHMcbUHoI:gitter.im/$q1_pINNMgSQ5GTx4F47frbW932rKdkZ4SRrglG-4EMA?via=gitter.im&via=matrix.org&via=nitro.chat