### PR TITLE
Revert "Update ruby Docker tag to v3.4"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   web:
-    image: ruby:3.4
+    image: ruby:3.3
     working_dir: /src
     command: /bin/bash -c "(bundle check || bundle install --jobs=3) && bundle exec jekyll serve --host=0.0.0.0 --incremental --livereload"
     ports:


### PR DESCRIPTION
Reverts crystal-lang/crystal-website#882

Jekyll doesn't support Ruby 3.4 yet 😢 
https://github.com/jekyll/jekyll/pull/9522