### PR TITLE
Fixup markdown

### DIFF
--- a/_releases/2025-01-09-1.15.0-released.md
+++ b/_releases/2025-01-09-1.15.0-released.md
@@ -242,7 +242,7 @@ _Thanks [@luislavena] and [@miry]_
 
 ### Deprecations
 
-- [`Process::Status#exit_status`]: Use [`#exit_reason`], [`#exit_code`], or [`#system_exit_status`] instead ([#8647])
+- [`Process::Status#exit_status`]\: Use [`#exit_reason`], [`#exit_code`], or [`#system_exit_status`] instead ([#8647])
   (more details in [_More portable `Process::Status`_](#more-portable-processstatus)).
 
 ---


### PR DESCRIPTION
Apparently the markdown parser considers this a ref declaration, even though it's in a list. Adding a backslash to escape the colon fixes that.