### PR TITLE
Add Msys2 package to installation page

### DIFF
--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -235,9 +235,9 @@
     ```shell
     pacman -S mingw-w64-x86_64-crystal
     ```
-  repo_href: https://packages.msys2.org/packages/mingw-w64-x86_64-crystal
+  repo_href: https://packages.msys2.org/base/mingw-w64-crystal
   repo_description: Crystal package in MSYS2
-  repology: msys2_mingw
+  repology: msys2_ucrt64
 
 ### FreeBSD
 

--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -227,13 +227,13 @@
   title: MSYS2
   example: |
     ```shell
-    pacman -S mingw-w64-ucrt-x86_64-crystal
+    pacman -S mingw-w64-ucrt-x86_64-crystal mingw-w64-ucrt-x86_64-shards
     ```
     ```shell
-    pacman -S mingw-w64-clang-x86_64-crystal
+    pacman -S mingw-w64-clang-x86_64-crystal mingw-w64-clang-x86_64-shards
     ```
     ```shell
-    pacman -S mingw-w64-x86_64-crystal
+    pacman -S mingw-w64-x86_64-crystal mingw-w64-x86_64-shards
     ```
   repo_href: https://packages.msys2.org/base/mingw-w64-crystal
   repo_description: Crystal package in MSYS2

--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -221,6 +221,18 @@
   repo_description: Crystal manifest in WinGet packages repository
   repology: winget
 
+- type: community
+  os: Windows
+  arch: [x86_64]
+  title: Msys2
+  example: |
+    ```shell
+    pacman -S mingw-w64-x86_64-crystal
+    ```
+  repo_href: https://packages.msys2.org/packages/mingw-w64-x86_64-crystal
+  repo_description: Crystal package in Msys2
+  repology: msys2_mingw
+
 ### FreeBSD
 
 - type: system

--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -224,13 +224,13 @@
 - type: community
   os: Windows
   arch: [x86_64]
-  title: Msys2
+  title: MSYS2
   example: |
     ```shell
     pacman -S mingw-w64-x86_64-crystal
     ```
   repo_href: https://packages.msys2.org/packages/mingw-w64-x86_64-crystal
-  repo_description: Crystal package in Msys2
+  repo_description: Crystal package in MSYS2
   repology: msys2_mingw
 
 ### FreeBSD

--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -224,7 +224,7 @@
 - type: community
   os: Windows
   arch: [x86_64]
-  title: "MSYS2: UCRT42"
+  title: "MSYS2: UCRT64"
   example: |
     ```shell
     pacman -S mingw-w64-ucrt-x86_64-crystal mingw-w64-ucrt-x86_64-shards
@@ -255,7 +255,7 @@
     ```
   repo_href: https://packages.msys2.org/packages/mingw-w64-x86_64-crystal
   repo_description: Crystal package in MSYS2
-  repology: msys2_clang64
+  repology: msys2_mingw
 
 ### FreeBSD
 

--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -224,20 +224,38 @@
 - type: community
   os: Windows
   arch: [x86_64]
-  title: MSYS2
+  title: "MSYS2: UCRT42"
   example: |
     ```shell
     pacman -S mingw-w64-ucrt-x86_64-crystal mingw-w64-ucrt-x86_64-shards
     ```
+  repo_href: https://packages.msys2.org/packages/mingw-w64-ucrt-x86_64-crystal
+  repo_description: Crystal package in MSYS2
+  repology: msys2_ucrt64
+
+- type: community
+  os: Windows
+  arch: [x86_64]
+  title: "MSYS2: Clang64"
+  example: |
     ```shell
     pacman -S mingw-w64-clang-x86_64-crystal mingw-w64-clang-x86_64-shards
     ```
+  repo_href: https://packages.msys2.org/packages/mingw-w64-clang-x86_64-crystal
+  repo_description: Crystal package in MSYS2
+  repology: msys2_clang64
+
+- type: community
+  os: Windows
+  arch: [x86_64]
+  title: "MSYS2: MinGW64"
+  example: |
     ```shell
     pacman -S mingw-w64-x86_64-crystal mingw-w64-x86_64-shards
     ```
-  repo_href: https://packages.msys2.org/base/mingw-w64-crystal
+  repo_href: https://packages.msys2.org/packages/mingw-w64-x86_64-crystal
   repo_description: Crystal package in MSYS2
-  repology: msys2_ucrt64
+  repology: msys2_clang64
 
 ### FreeBSD
 

--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -227,6 +227,12 @@
   title: MSYS2
   example: |
     ```shell
+    pacman -S mingw-w64-ucrt-x86_64-crystal
+    ```
+    ```shell
+    pacman -S mingw-w64-clang-x86_64-crystal
+    ```
+    ```shell
     pacman -S mingw-w64-x86_64-crystal
     ```
   repo_href: https://packages.msys2.org/packages/mingw-w64-x86_64-crystal


### PR DESCRIPTION
Note: shards is not yet available in the MSYS2 repository.