### PR TITLE
Add links to external discussions

### DIFF
--- a/_includes/posts/discussions.html
+++ b/_includes/posts/discussions.html
@@ -1,0 +1,23 @@
+<div class="post-discussions">
+  <h2 id="discussions">Discussions on the web</h2>
+
+  <ul>
+  {% for discussion in page.discussions %}
+    <li><a href="{{ discussion.url }}"><strong>{{ discussion.title }}</strong></a> (<time datetime="{{ discussion.timestamp | date_to_xml }}"
+      >{{ discussion.timestamp | date_to_string }}</time
+    >) on {{ discussion.site }}
+    {% if discussion.comments_count or discussion.score %}
+      <em class="post-discussion-stats">
+        ({% if discussion.score -%}
+          {{ discussion.score }} points
+        {% endif %}
+        {% if discussion.score and discussion.comments_count %} · {% endif %}
+        {% if discussion.comments_count %}
+          {{ discussion.comments_count }} comments{%
+          endif %})
+      </em>
+    {% endif %}
+    </li>
+  {% endfor %}
+  </ul>
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -23,6 +23,10 @@ layout: base
   <div class="post__body">
     <div class="content" itemprop="articleBody">{{ content }}</div>
 
+    {% if page.discussions %}
+      {% include posts/discussions.html %}
+    {% endif %}
+
     {% include discourse_comments.html %}
 
     {% if page.comment_href %}

--- a/_releases/2025-04-09-1.16.0-released.md
+++ b/_releases/2025-04-09-1.16.0-released.md
@@ -3,6 +3,13 @@ title: Crystal 1.16.0 is released!
 version: 1.16.0
 date: 2025-04-09
 author: straight-shoota
+discussions:
+- url: "https://news.ycombinator.com/item?id=43649618"
+  site: HackerNews
+  title: Crystal 1.16.0
+  timestamp: 2025-04-11T01:36:45 1744335405
+  comments_count: 29
+  score: 102
 ---
 
 We are announcing a new Crystal release 1.16.0 with several new features and bug fixes.

--- a/_sass/components/_post-discussions.scss
+++ b/_sass/components/_post-discussions.scss
@@ -1,0 +1,8 @@
+.post-discussions {
+  margin-block-start: var(--padding-lg);
+  max-width: var(--content-width);
+
+  h2 {
+    font-size: font-size(h4);
+  }
+}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -49,6 +49,7 @@
   @import "components/link-actions";
   @import "components/navbar";
   @import "components/partner-images";
+  @import "components/post-discussions";
   @import "components/post-teaser";
   @import "components/post-navigation";
   @import "components/side-section";


### PR DESCRIPTION
When there are good discussions about blog posts (or releases etc.) elsewhere on the web, it's great to link there.
This patch does that for the current 1.16.0 release notes, which are discussed on Hacker News.

![grafik](https://github.com/user-attachments/assets/aa091195-c659-4c68-b4d3-b2b2b566e634)

Idea inspired by https://jonathan-frere.com/posts/adding-discussions/
The process of adding backlinks could even be automated in the future.
