### PR TITLE
Fix pre-commit run to-ref [fixup #926]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,4 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - env:
-          TO_REF: "${{ github.head_ref || github.ref }}"
-        run: devenv shell -- pre-commit run --from-ref ${{ github.base_ref || 'master' }} --to-ref "$TO_REF"
+      - run: devenv shell -- pre-commit run --from-ref "origin/${{ github.base_ref || 'master' }}" --to-ref HEAD

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,5 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
+      - run: git fetch origin/master
       - run: devenv shell -- pre-commit run --from-ref "origin/${{ github.base_ref || 'master' }}" --to-ref HEAD

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,5 +17,5 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - run: git remote -v
+      - run: git fetch origin master
       - run: devenv shell -- pre-commit run --from-ref "origin/${{ github.base_ref || 'master' }}" --to-ref HEAD

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,5 +17,5 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - run: git fetch origin/master
+      - run: git remote -v
       - run: devenv shell -- pre-commit run --from-ref "origin/${{ github.base_ref || 'master' }}" --to-ref HEAD

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,6 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - run: devenv shell -- pre-commit run --from-ref ${{ github.base_ref || 'master' }} --to-ref ${{ github.ref }}
+      - env:
+          TO_REF: "${{ github.head_ref || github.ref }}"
+        run: devenv shell -- pre-commit run --from-ref ${{ github.base_ref || 'master' }} --to-ref "$TO_REF"

--- a/_sass/elements/_hex-icon.scss
+++ b/_sass/elements/_hex-icon.scss
@@ -10,9 +10,9 @@
   display: inline-block;
   position: relative;
 
-  filter: drop-shadow(0 0 2px rgba(0,0,0,0.1))
-    drop-shadow(0 1px 1px rgba(0,0,0,0.2))
-    drop-shadow(0 1px 1px rgba(0,0,0,0.1));
+  filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.1))
+    drop-shadow(0 1px 1px rgba(0, 0, 0, 0.2))
+    drop-shadow(0 1px 1px rgba(0, 0, 0, 0.1));
 
   .inner {
     background-color: white;


### PR DESCRIPTION
`github.ref` doesn't give usable value for `pull_request` triggered workflow. They must use `github.head_ref` instead.