### PR TITLE
Relable home button from _Learn_ to _Get Started_

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -23,7 +23,7 @@ site_title: The Crystal Programming Language
 
     <div class="actions">
       <a href="/install/" class="hex"><span>Install</span></a>
-      <a href="https://crystal-lang.org/reference/getting_started/" class="hex"><span>Learn</span></a>
+      <a href="https://crystal-lang.org/reference/getting_started/" class="hex"><span>Get Started</span></a>
       <a href="https://play.crystal-lang.org/#/cr" class="hex"><span>Try Online</span></a>
     </div>
   </div>


### PR DESCRIPTION
This is more accurate because the target page is "Getting Started".