### PR TITLE
Move _Install_ page to install section

### DIFF
--- a/_data/sections.yaml
+++ b/_data/sections.yaml
@@ -61,7 +61,6 @@ home:
 install:
   title: Install
   breadcrumbs:
-    - title: Docs
     - title: Install
       url: /install/
       nav: install

--- a/_pages/install.md
+++ b/_pages/install.md
@@ -3,7 +3,7 @@ title: Install
 permalink: /install/
 layout: page-wide
 page_class: page--segmented
-section: docs
+section: install
 description: |
   Packages for [Crystal releases](/releases) are available from different sources.
   There are official ones provided the Crystal project, system packages and


### PR DESCRIPTION
Sub pages are already in the install section, so this might make things a bit clearer.

There is some duplication between the section nav link actions on the page, though.

![grafik](https://github.com/user-attachments/assets/0e1e5de3-bde2-4b92-b7c9-0040d40f1cd8)



There's also no real reason to put the install section as a sub section of *Docs*.