### PR TITLE
Enable dotenv in devenv config

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -34,4 +34,6 @@
     };
     typos.enable = true;
   };
+
+  dotenv.enable = true;
 }


### PR DESCRIPTION
This allows using `.env` files for local environment variables, such as GITHUB_TOKEN.