### PR TITLE
Typo in funding.json URL

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -22,7 +22,7 @@ layout: none
         "url": "https://crystal-lang.org/"
       },
       "repositoryUrl": {
-        "url": "https:///github.com/crystal-lang/crystal",
+        "url": "https://github.com/crystal-lang/crystal",
         "wellKnown": "https://github.com/crystal-lang/crystal/blob/master/.well-known/funding-manifest-urls"
       },
       "licenses": [


### PR DESCRIPTION
There was an extra `/` in the scheme.