### PR TITLE
Improve layout for `.properties` table

### DIFF
--- a/_sass/elements/_table.scss
+++ b/_sass/elements/_table.scss
@@ -27,8 +27,12 @@
   th,
   td {
     padding: 0.75em 0.9em;
-    border-block-end: 1px solid var(--border-color);
+    border-block-start: 1px solid var(--border-color);
     line-height: var(--line-height-md);
+  }
+
+  tr:last-child {
+    border-block-end: 1px solid var(--border-color);
   }
 
   &.properties {
@@ -37,12 +41,9 @@
       padding: 0.5em 0.9em;
     }
 
-    tr:first-child {
-      border-top: 1px solid var(--border-color);
-    }
-
     th {
       vertical-align: top;
+      width: 14em;
     }
 
     td {
@@ -60,9 +61,31 @@
       }
     }
 
-    tr:nth-child(2n + 1) td,
-    tr:nth-child(2n + 1) th {
+    :where(tr:nth-child(2n + 1)) td,
+    :where(tr:nth-child(2n + 1)) th {
       background-color: var(--background-secondary);
+    }
+
+    @media (width < 30em) {
+      tr,
+      td,
+      th {
+        display: block;
+      }
+
+      tr + tr {
+        margin-block-start: var(--padding-xs);
+      }
+
+      tr td {
+        background: none;
+      }
+
+      th {
+        background-color: var(--background-secondary);
+        border-block-end: none;
+        width: 100%;
+      }
     }
   }
 }

--- a/_sass/elements/_table.scss
+++ b/_sass/elements/_table.scss
@@ -41,6 +41,25 @@
       border-top: 1px solid var(--border-color);
     }
 
+    th {
+      vertical-align: top;
+    }
+
+    td {
+      > ul,
+      ol {
+        // Align text to the left and let list icon spill into the cell padding.
+        padding-inline-start: 0;
+
+        &:first-child {
+          margin-block-start: 0;
+        }
+        &:last-child {
+          margin-block-end: 0;
+        }
+      }
+    }
+
     tr:nth-child(2n + 1) td,
     tr:nth-child(2n + 1) th {
       background-color: var(--background-secondary);

--- a/_style_guide/typography/table.properties.html
+++ b/_style_guide/typography/table.properties.html
@@ -19,3 +19,29 @@ type: typography
     </tr>
   </tbody>
 </table>
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Status</th>
+      <td>🔵 In Progress, led by <a href="https://github.com/ysbaddaden">@ysbaddaden</a></td>
+    </tr>
+    <tr>
+      <th scope="row">Sponsored by</th>
+      <td><a href="https://84.codes/">84codes</a></td>
+    </tr>
+    <tr>
+      <th scope="row">Start
+        date</th>
+      <td>April 2025</td>
+    </tr>
+    <tr>
+      <th scope="row">Learn more</th>
+      <td>
+        <ul>
+          <li><a href="https://github.com/crystal-lang/crystal/issues/10740">Original issue</a></li>
+          <li><a href="https://github.com/crystal-lang/crystal/pull/15634">Epic issue</a></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
Breaks rows into columns on small viewports:

| Wide viewport | Narrow viewport |
|-|-|
| <img width="870" height="289" alt="grafik" src="https://github.com/user-attachments/assets/9552a66b-1513-4d33-a7ac-e95542302699" /> | <img width="469" height="543" alt="grafik" src="https://github.com/user-attachments/assets/1b5bede3-90d6-4cf2-88ac-efe40cd7263d" /> |

Useful for https://github.com/crystal-lang/crystal-website/pull/973