### PR TITLE
Add release highlights

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -93,3 +93,9 @@ home:
   url: /success-stories/
 - label: Sitemap
   url: /sitemap/
+
+releases:
+- label: Highlights
+  url: /releases/highlights/
+- label: Release Policy
+  url: https://crystal-lang.org/reference/project/release-policy.html

--- a/_data/sections.yaml
+++ b/_data/sections.yaml
@@ -91,6 +91,7 @@ releases:
   breadcrumbs:
   - title: Releases
     url: /releases/
+    nav: releases
   weight: 24
 
 unspecified:

--- a/_includes/pages/releases/releases-highlights.html
+++ b/_includes/pages/releases/releases-highlights.html
@@ -1,0 +1,17 @@
+{%- assign releases = site.releases | reverse %}
+{%- for release in releases %}
+  {%- assign suffix = release.version | slice: -2, 2 %}
+  {%- assign highlights = release.highlights %}
+  {% if highlights %}
+  <div class="release-highlights">
+    <h2>
+      <a href="{{ release.url }}">{{release.version}}</a>
+    <span class="release-date">
+      <time datetime="{{ release.date | date: '%F' }}">{{ release.date | date_to_string }}</time>
+    </span>
+    </h2>
+
+    {% include releases/highlights.html highlights=highlights %}
+  </div>
+  {% endif %}
+{%- endfor %}

--- a/_includes/pages/releases/releases-highlights.html
+++ b/_includes/pages/releases/releases-highlights.html
@@ -11,7 +11,7 @@
     </span>
     </h2>
 
-    {% include releases/highlights.html highlights=highlights %}
+    {% include releases/highlights.html highlights=highlights link_prefix=release.url %}
   </div>
   {% endif %}
 {%- endfor %}

--- a/_includes/releases/highlights.html
+++ b/_includes/releases/highlights.html
@@ -1,0 +1,10 @@
+<ul>
+{% for highlight in include.highlights %}
+  <li>
+    <span class="highlight">
+      <span>{{ highlight.text | markdownify | remove: "<p>" | remove: "</p>" }}</span>
+      <span class="label">{{ highlight.label }}</span>
+    </span>
+  </li>
+{% endfor %}
+</ul>

--- a/_includes/releases/highlights.html
+++ b/_includes/releases/highlights.html
@@ -1,8 +1,9 @@
 <ul>
 {% for highlight in include.highlights %}
+  {%- assign href_replacement = '<a href="' |append: include.link_prefix | append: '#' -%}
   <li>
     <span class="highlight">
-      <span>{{ highlight.text | markdownify | remove: "<p>" | remove: "</p>" }}</span>
+      <span>{{ highlight.text | markdownify | remove: "<p>" | remove: "</p>" | replace: '<a href="#', href_replacement }}</span>
       <span class="label">{{ highlight.label }}</span>
     </span>
   </li>

--- a/_includes/releases/release_highlights.html
+++ b/_includes/releases/release_highlights.html
@@ -1,0 +1,5 @@
+<div class="release-highlights">
+  <h2>Highlights</h2>
+
+  {% include releases/highlights.html highlights=include.release.highlights %}
+</div>

--- a/_layouts/release.html
+++ b/_layouts/release.html
@@ -1,6 +1,8 @@
 ---
 layout: post
 ---
-{% include releases/links.html release = page %}
+{% include releases/links.html release=page %}
+
+{% include releases/release_highlights.html release=page %}
 
 {{ content }}

--- a/_pages/releases.md
+++ b/_pages/releases.md
@@ -13,7 +13,6 @@ link_actions:
   </a>
 - '[Installation instructions](/install)'
 - '[GitHub Releases](https://github.com/crystal-lang/crystal/releases)'
-- '[Release Policy](https://crystal-lang.org/reference/project/release-policy.html)'
 ---
 
 {% include pages/releases/releases-table.html %}

--- a/_pages/releases/highlights.md
+++ b/_pages/releases/highlights.md
@@ -1,0 +1,9 @@
+---
+title: Release highlights
+layout: page-wide
+section: releases
+description: |
+  Highlights of previous Crystal releases
+---
+
+{% include pages/releases/releases-highlights.html %}

--- a/_releases/2021-03-22-crystal-1.0-what-to-expect.md
+++ b/_releases/2021-03-22-crystal-1.0-what-to-expect.md
@@ -4,6 +4,13 @@ version: 1.0.0
 summary: Crystal 1.0.0 is here
 author: asterite,bcardiff,waj,450
 comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_10_what_to_expect_51/
+highlights:
+- text: "[Removed deprecated features](#standard-library)"
+  label: stdlib
+- text: "[Type-safe tuple accessors with literal ranges](#language-changes)"
+  label: lang/tuples
+- text: "[New fine-grained rounding modes](#numeric)"
+  label: stdlib/numeric
 ---
 
 The release of the first major release of Crystal arrives after many years of hard work. With thousands of contributions from people worldwide, it was finally possible to find consensus for what truly mattered for 1.0 and what could wait for future releases. Getting here wasn’t an easy journey, filled with enriching, controversial, delightful, and endless conversations that, in the end, made it possible to build a language more useful for more users.

--- a/_releases/2021-07-16-1.1.0-released.md
+++ b/_releases/2021-07-16-1.1.0-released.md
@@ -4,6 +4,15 @@ version: 1.1.0
 summary: The first post-1.0 release
 author: beta-ziliani
 comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_110_is_released/
+highlights:
+- text: "[Splat embedding in enumerable literals and type definitions](#language-changes)"
+  label: lang
+- text: "[`while` are typed as a union of all `break` expressions plus `Nil`](#language-changes)"
+  label: lang
+- text: "[New `@top_level` macro variable](#macros)"
+  label: lang/macros
+- text: "[Segfault handler implemented in Crystal, no `libcrystal` anymore](#runtime)"
+  label: stdlib/runtime
 ---
 
 We are releasing the first post-1.0 release, making efforts to keep our promise of making regular releases each 3 months, a bit delayed because of the [conference](/conference), and with special focus on keeping the language stability. Below we list the most important or interesting changes, without mentioning the several bugfixes. For details visit the [release's notes](https://github.com/crystal-lang/crystal/releases/tag/1.1.0).

--- a/_releases/2021-10-14-1.2.0-released.md
+++ b/_releases/2021-10-14-1.2.0-released.md
@@ -9,7 +9,7 @@ highlights:
   label: platform
 - text: "[Dropped disfunct ThinLTO support](#language-changes)"
   label: compiler/linking
-- text: "[Render markdown with `markd` shard](#tools:-new-docs-generator)"
+- text: "[Render markdown with `markd` shard](#tools-new-docs-generator)"
   label: compiler/docs
 - text: "[Support for 128-bit integers](#numeric)"
   label: stdlib/numeric

--- a/_releases/2021-10-14-1.2.0-released.md
+++ b/_releases/2021-10-14-1.2.0-released.md
@@ -4,6 +4,17 @@ version: 1.2.0
 summary: Improving platform support
 author: beta-ziliani
 comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_120_is_released_32/
+highlights:
+- text: "[`aarch64-darwin` promotes to tier 2, `i386-linux-gnu` demoted to tier 2](#platform-support)"
+  label: platform
+- text: "[Dropped disfunct ThinLTO support](#language-changes)"
+  label: compiler/linking
+- text: "[Render markdown with `markd` shard](#tools:-new-docs-generator)"
+  label: compiler/docs
+- text: "[Support for 128-bit integers](#numeric)"
+  label: stdlib/numeric
+- text: "[`Indexable::Mutable(T)` module](#collections)"
+  label: stdlib/collections
 ---
 
 We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning the several bugfixes. For details visit the [release's notes](https://github.com/crystal-lang/crystal/releases/tag/1.2.0). Breaking changes are marked with ⚠️.

--- a/_releases/2022-01-06-1.3.0-released.md
+++ b/_releases/2022-01-06-1.3.0-released.md
@@ -1,6 +1,19 @@
 ---
 title: Crystal 1.3.0 is released!
 version: 1.3.0
+highlights:
+- text: "[Autocasting for primitive numeric values](#number-autocast)"
+  label: lang/numeric
+- text: "[128-bit number literals](#128-bit-literals)"
+  label: lang/numeric
+- text: "[Interpreter preview merged](#interpreter)"
+  label: compiler/interpreter
+- text: "[Windows packages available](#windows-support)"
+  label: platform/windows
+- text: "[Experimental `Syscall` API](#syscalls)"
+  label: stdlib/system
+- text: "[Splat support in multi-assign](#multi-assign)"
+  label: lang
 ---
 
 We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements. For more details, visit the [changelog](https://github.com/crystal-lang/crystal/releases/tag/1.3.0). Breaking changes are marked with ⚠️.

--- a/_releases/2022-04-06-1.4.0-released.md
+++ b/_releases/2022-04-06-1.4.0-released.md
@@ -2,6 +2,13 @@
 title: Crystal 1.4.0 is released!
 version: 1.4.0
 comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_140_is_released/
+highlights:
+- text: "[Experimental support for WebAssembly (`wasm32-wasi`)](#towards-wasm-support)"
+  label: platform/wasm
+- text: "[Improved type inference for instance and class variables](#better-type-inference-for-instance-and-class-variables)"
+  label: lang/types
+- text: "[Support for LLVM 14](#other-remarkable-changes)"
+  label: stdlib/llvm
 ---
 
 Celebrating the first year of the 1.X series of our beloved language, we are delivering a new release with several bugfixes and improvements.

--- a/_releases/2022-07-06-1.5.0-released.md
+++ b/_releases/2022-07-06-1.5.0-released.md
@@ -1,6 +1,11 @@
 ---
 title: Crystal 1.5.0 is released!
 version: 1.5.0
+highlights:
+- text: "[Types of instance variables propagate to method parameter restrictions](#method-restrictions-from-instance-variables)"
+  label: lang/types
+- text: "[Annotations on method parameters](#annotations-allowed-on-method-arguments)"
+  label: lang/annotations
 ---
 
 We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements. For more details, visit the [changelog](https://github.com/crystal-lang/crystal/releases/tag/1.5.0). Breaking changes are marked with ⚠️.

--- a/_releases/2022-10-06-1.6.0-released.md
+++ b/_releases/2022-10-06-1.6.0-released.md
@@ -2,6 +2,9 @@
 title: Crystal 1.6.0 is released!
 version: 1.6.0
 comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_160_is_released/
+highlights:
+- text: "[Improved overload ordering](#️-improvements-in-overload-ordering)"
+  label: lang/types
 ---
 
 We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements. For more details, visit the [changelog](https://github.com/crystal-lang/crystal/releases/tag/1.6.0). Breaking changes are marked with ⚠️.

--- a/_releases/2023-01-09-1.7.0-released.md
+++ b/_releases/2023-01-09-1.7.0-released.md
@@ -2,6 +2,9 @@
 title: Crystal 1.7.0 is released!
 version: 1.7.0
 comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_170_is_released/
+highlights:
+- text: "[Preview for PCRE2](#regex-with-pcre2)"
+  label: stdlib/text
 ---
 
 We are starting the year with a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements. For more details, visit the [changelog](https://github.com/crystal-lang/crystal/releases/tag/1.7.0). Breaking changes are marked with ⚠️.

--- a/_releases/2023-04-14-1.8.0-released.md
+++ b/_releases/2023-04-14-1.8.0-released.md
@@ -2,6 +2,19 @@
 title: Crystal 1.8.0 is released!
 version: 1.8.0
 comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_180_is_released_85/
+highlights:
+- text: "[PCRE2 default regex engine](#regex-pcre2)"
+  label: stdlib/text
+- text: "[Regex literals expect PCRE2 syntax](#regex-pcre2)"
+  label: lang/literals
+- text: "[Support for LLVM 15 with opaque pointers](#llvm-updates)"
+  label: stdlib/llvm
+- text: "[`x86_64-linux-musl` promoted to tier 1](#platform-support)"
+  label: platform/linux
+- text: "[New target `aarch64-linux-android`](#platform-support)"
+  label: platform/android
+- text: "[New portable APIs for process-lifecycle events](#signal)"
+  label: stdlib/system
 ---
 
 We are delivering a new release with several bugfixes and improvements. Below we list the most important or interesting changes, without mentioning several bugfixes and smaller enhancements. For more details, visit the [changelog](https://github.com/crystal-lang/crystal/releases/tag/1.8.0). Breaking changes are marked with ⚠️.

--- a/_releases/2023-07-11-1.9.0-released.md
+++ b/_releases/2023-07-11-1.9.0-released.md
@@ -2,6 +2,13 @@
 title: Crystal 1.9.0 is released!
 version: 1.9.0
 author: straight-shoota
+highlights:
+- text: "[Comparison with `Big*` types are now nilable](#breaking-big-number-comparisons-with-floats)"
+  label: stdlib/numeric
+- text: "[New command `crystal clear_cache`](#compiler)"
+  label: compiler/tools
+- text: "[Support for LLVM 16](#compiler)"
+  label: stdlib/llvm
 ---
 
 We are delivering a new Crystal release with several bugfixes and improvements.

--- a/_releases/2023-10-09-1.10.0-released.md
+++ b/_releases/2023-10-09-1.10.0-released.md
@@ -3,6 +3,11 @@ title: Crystal 1.10.0 is released!
 version: 1.10.0
 author: straight-shoota
 comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_1100_is_released/
+highlights:
+- text: "[Unpacking for nested block parameter with splat support](#unlimited-block-unpacking)"
+  label: lang/blocks
+- text: "[New commands `crystal tool dependencies` and `crystal tool unreachable`](#compiler-tools-dependencies-and-unreachable)"
+  label: compiler/tools
 ---
 
 We are delivering a new Crystal release with several bugfixes and improvements.

--- a/_releases/2024-01-08-1.11.0-released.md
+++ b/_releases/2024-01-08-1.11.0-released.md
@@ -4,7 +4,19 @@ version: 1.11.0
 date: 2024-01-08
 author: straight-shoota
 comment_href: https://disqus.com/home/discussion/crystal-lang/crystal_1110_is_released/
+highlights:
+- text: "[New compiler optimization levels](#compiler-optimization-levels)"
+  label: compiler/codegen
+- text: "[New alignment primitives `alignof` and `instance_alignof`](#alignment-primitives)"
+  label: lang/primitives
+- text: "[`dll` parameter for `@[Link]` annotations](#dll-parameter-in-link-annotation)"
+  label: lang/annotations
+- text: "[Macro call context accessible as `@caller`](#macro-caller-context)"
+  label: lang/macros
+- text: "[Support for LLVM 18 allows dropping `llvm_ext`](#llvm-18)"
+  label: stdlib/llvm
 ---
+
 We are announcing a new Crystal release with several new features and bug fixes.
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.11.0)

--- a/_releases/2024-01-11-1.11.1-released.md
+++ b/_releases/2024-01-11-1.11.1-released.md
@@ -4,6 +4,7 @@ version: 1.11.1
 date: 2024-01-11
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.11 series](/2024/01/08/1.11.0-released/) with some important bugfixes.
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.11.1) and our official distribution channels.

--- a/_releases/2024-01-18-1.11.2-released.md
+++ b/_releases/2024-01-18-1.11.2-released.md
@@ -4,6 +4,7 @@ version: 1.11.2
 date: 2024-01-18
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.11 series](/2024/01/08/1.11.0-released/). Crystal 1.11.2 fixes some regressions from 1.11.0.
 
 Builds are available for all supported platforms: [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.11.2), [docker images 🐋](https://hub.docker.com/r/crystallang/crystal/), [snapcraft](https://snapcraft.io/crystal), `.deb` and `.rpm` packages, Windows builds and the brew formula 🍻.

--- a/_releases/2024-04-09-1.12.0-released.md
+++ b/_releases/2024-04-09-1.12.0-released.md
@@ -3,6 +3,19 @@ title: Crystal 1.12.0 is released!
 version: 1.12.0
 date: 2024-04-09
 author: straight-shoota
+highlights:
+- text: "[`Process.on_terminate` for portable handling termination requests](#process-termination-handler)"
+  label: stdlib/system
+- text: "[LLVM 18 and deprecation of `llvm_ext`](#libraries)"
+  label: stdlib/llvm
+- text: "[Assignment operators can receive multiple parameters and blocks](#operators-with--suffix)"
+  label: lang
+- text: "[Preliminary support for Solaris/Illumos](#compiler)"
+  label: platform/solaris
+- text: "[New command: `crystal tool flags`](#crystal-tool-flags)"
+  label: compiler/tools
+- text: "[Experimental support for `ReferenceStorage` to control reference allocations](#experimental-referencestorage)"
+  label: lang
 ---
 
 We are announcing a new Crystal release with several new features and bug fixes.

--- a/_releases/2024-04-11-1.12.1-released.md
+++ b/_releases/2024-04-11-1.12.1-released.md
@@ -4,6 +4,7 @@ version: 1.12.1
 date: 2024-04-11
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.12 series](/_releases/2024-04-09-1.12.0-released.md) with an important bugfix.
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.12.1)

--- a/_releases/2024-05-31-1.12.2-released.md
+++ b/_releases/2024-05-31-1.12.2-released.md
@@ -4,6 +4,7 @@ version: 1.12.2
 date: 2024-05-31
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.12 series](/_releases/2024-04-09-1.12.0-released.md) with an important bugfix.
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.12.2)

--- a/_releases/2024-07-09-1.13.0-released.md
+++ b/_releases/2024-07-09-1.13.0-released.md
@@ -3,7 +3,19 @@ title: Crystal 1.13.0 is released!
 version: 1.13.0
 date: 2024-07-09
 author: straight-shoota
+highlights:
+- text: "[OpenSSL now uses the library default configuration](#openssl-default-configuration)"
+  label: stdlib/crypto
+- text: "[`rescue` supports module types](#rescue-module-types)"
+  label: lang
+- text: "[Runtime tracing with `-Dtracing`](#runtime-tracing)"
+  label: stdlib/runtime
+- text: "[`WaitGroup` for waiting on concurrent fibers](#waitgroup)"
+  label: stdlib/concurrency
+- text: "[Basic support for AVR architecture (Adrduino)](#compiler)"
+  label: platform/arduino
 ---
+
 We are announcing a new Crystal release with several new features and bug fixes.
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.13.0)

--- a/_releases/2024-07-09-1.13.0-released.md
+++ b/_releases/2024-07-09-1.13.0-released.md
@@ -139,6 +139,15 @@ wg.wait
 
 _Thanks [@ysbaddaden] and [84codes](https://www.84codes.com/)_
 
+### Atomics
+
+`Atomic` supports `Bool` and `Pointer` types ([#14401], [#14532]).
+
+[#14401]: https://github.com/crystal-lang/crystal/pull/14401
+[#14532]: https://github.com/crystal-lang/crystal/pull/14532
+
+_Thanks [@ysbaddaden] and [@HertzDevil]_
+
 ### Compiler
 
 - New compiler flags `-Os` and `-Oz` to optimize binary size ([#14463](https://github.com/crystal-lang/crystal/pull/14463)).

--- a/_releases/2024-07-12-1.13.1-released.md
+++ b/_releases/2024-07-12-1.13.1-released.md
@@ -4,6 +4,7 @@ version: 1.13.1
 date: 2024-07-12
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.13 series](/_releases/2024-07-09-1.13.0-released.md) to fix a regression with Unicode strings in the JSON parser.
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.13.1)

--- a/_releases/2024-08-20-crystal-1.13.2-released.md
+++ b/_releases/2024-08-20-crystal-1.13.2-released.md
@@ -4,6 +4,7 @@ version: 1.13.2
 date: 2024-08-20
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.13 series](/_releases/2024-07-09-1.13.0-released.md) with a couple of important bug fixes.
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.13.2)

--- a/_releases/2024-09-18-1.13.3-released.md
+++ b/_releases/2024-09-18-1.13.3-released.md
@@ -4,6 +4,7 @@ version: 1.13.3
 date: 2024-09-18
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.13 series](/_releases/2024-07-09-1.13.0-released.md) with a couple of important bug fixes.
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.13.3)

--- a/_releases/2024-10-09-1.14.0-released.md
+++ b/_releases/2024-10-09-1.14.0-released.md
@@ -3,7 +3,17 @@ title: Crystal 1.14.0 is released!
 version: 1.14.0
 date: 2024-10-09
 author: straight-shoota
+highlights:
+- text: "[`XML::Error.errors` fails to compile to prevent error leaks](#breaking)"
+  label: stdlib/xml
+- text: "[Platform support for `aarch64-windows-msvc`](#windows)"
+  label: platform/windows
+- text: "[Compiler can execute external programs as subcommands](#compiler-tools)"
+  label: compiler/cli
+- text: "[Support for LLVM 19.1](#dependency-updates)"
+  label: stdlib/llvm
 ---
+
 We are announcing a new Crystal release with several new features and bug fixes.
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.14.0)

--- a/_releases/2025-01-08-1.14.1-released.md
+++ b/_releases/2025-01-08-1.14.1-released.md
@@ -4,6 +4,7 @@ version: 1.14.1
 date: 2025-01-08
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.14 series](/_releases/2024-10-09-1.14.0-released.md).
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.14.1)

--- a/_releases/2025-01-09-1.15.0-released.md
+++ b/_releases/2025-01-09-1.15.0-released.md
@@ -3,6 +3,19 @@ title: Crystal 1.15.0 is released!
 version: 1.15.0
 date: 2025-01-09
 author: straight-shoota
+highlights:
+- text: "[Constants can start with any upper- or titlecase letter](#breaking)"
+  label: lang
+- text: "[Lifetime eventloop integrates directly with system selector](#lifetime-eventloop)"
+  label: stdlib/runtime
+- text: "[Indirect branch tracking](#stabilized-platform-support)"
+  label: compiler/codegen
+- text: "[MinGW-W64 and MSYS2 as alternative toolchains on Windows](#windows)"
+  label: platform/windows
+- text: "[`Process::Status` more portable](#more-portable-processstatus)"
+  label: stdlib/system
+- text: "[Pending formatter changes enable by default](#compiler-tools)"
+  label: compiler/formatter
 ---
 
 We are announcing a new Crystal release 1.15.0 with several new features and bug fixes.
@@ -163,7 +176,7 @@ _Thanks [@jgaskins]_
 
 `Log` messages do not emit when issued with a block and the block returns `nil`.
 This was incorrectly also the case even when an `exception` instance was passed
-to the emit method. This was fixed in [#15253] and a message is now emitted when
+  to the emit method. This was fixed in ([#15253]) and a message is now emitted when
 an exception is passed. We also added new overloads for passing an exception
 without giving a block ([#15257]).
 

--- a/_releases/2025-02-04-1.15.1-released.md
+++ b/_releases/2025-02-04-1.15.1-released.md
@@ -4,6 +4,7 @@ version: 1.15.1
 date: 2025-02-04
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.15 series](/_releases/2025-01-09-1.15.0-released.md).
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.15.1)

--- a/_releases/2025-04-09-1.16.0-released.md
+++ b/_releases/2025-04-09-1.16.0-released.md
@@ -10,6 +10,17 @@ discussions:
   timestamp: 2025-04-11T01:36:45 1744335405
   comments_count: 29
   score: 102
+highlights:
+- text: "[New algorithm for `File.match?` fixes implementation bugs](#fixed-implementation-of-filematch)"
+  label: stdlib/system
+- text: "[Suffixes `?` and `!` for parameter names are deprecated](#parameter-name-suffixes-are-deprecated)"
+  label: lang
+- text: "[Preview for execution contexts](#execution-contexts)"
+  label: stdlib/runtime
+- text: "[`:showdoc:` primitive for inclusion in API docs](#compiler-tools)"
+  label: compiler/docs
+- text: "[Support for LLVM 20](#dependency-updates)"
+  label: stdlib/llvm
 ---
 
 We are announcing a new Crystal release 1.16.0 with several new features and bug fixes.

--- a/_releases/2025-04-16-1.16.1-released.md
+++ b/_releases/2025-04-16-1.16.1-released.md
@@ -4,6 +4,7 @@ version: 1.16.1
 date: 2025-04-16
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.16 series](/_releases/2025-04-09-1.16.0-released.md).
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.16.1)

--- a/_releases/2025-04-29-1.16.2-released.md
+++ b/_releases/2025-04-29-1.16.2-released.md
@@ -4,6 +4,7 @@ version: 1.16.2
 date: 2025-04-29
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.16 series](/_releases/2025-04-09-1.16.0-released.md).
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.16.2)

--- a/_releases/2025-05-12-1.16.3-released.md
+++ b/_releases/2025-05-12-1.16.3-released.md
@@ -4,6 +4,7 @@ version: 1.16.3
 date: 2025-05-12
 author: straight-shoota
 ---
+
 We are announcing a new patch release of the Crystal [1.16 series](/_releases/2025-04-09-1.16.0-released.md).
 
 Pre-built packages are available on [GitHub Releases](https://github.com/crystal-lang/crystal/releases/tag/1.16.3)

--- a/_releases/2025-07-16-1.17.0-released.md
+++ b/_releases/2025-07-16-1.17.0-released.md
@@ -3,6 +3,13 @@ title: Crystal 1.17.0 is released!
 version: 1.17.0
 date: 2025-07-16
 author: straight-shoota
+highlights:
+- text: "[Event loop decides blocking mode when creating file descriptors](#blocking-behaviour-of-file-descriptors)"
+  label: stdlib/system
+- text: "[New command: `crystal tool macro_code_coverage`](#compiler-tools)"
+  label: compiler/tools
+- text: "[Support for LLVM 21](#dependencies)"
+  label: stdlib/llvm
 ---
 
 We are announcing a new Crystal release 1.17.0 with several new features and bug

--- a/_releases/2025-10-14-1.18.0-released.md
+++ b/_releases/2025-10-14-1.18.0-released.md
@@ -3,6 +3,11 @@ title: Crystal 1.18.0 is released!
 version: 1.18.0
 date: 2025-10-14
 author: straight-shoota
+highlights:
+- text: "[Deprecation annotations on types and parameters](#deprecation-warnings)"
+  label: lang/annotations
+- text: "[Support for LLVM 22](#dependencies)"
+  label: stdlib/llvm
 ---
 
 We are announcing a new Crystal release 1.18.0 with several new features and bug

--- a/_releases/2026-01-15-1.19.0-released.md
+++ b/_releases/2026-01-15-1.19.0-released.md
@@ -3,6 +3,15 @@ title: Crystal 1.19.0 is released!
 version: 1.19.0
 date: 2026-01-15
 author: ysbaddaden
+highlights:
+- text: "[Compiler flags with values](#Compiler flags now have values)"
+  label: compiler
+- text: "[Execution contexts in final preview including new `Sync` primitives](#Execution contexts)"
+  label: stdlib/runtime
+- text: "[Introduce `Time::Instant`](#time) and [adjust behaviour of monotonic clocks](#Adjust monotonic clocks)"
+  label: stdlib/time
+- text: "[Process spawning refactor and safer exec handling](#Process)"
+  label: stdlib/process
 ---
 
 We are announcing a new Crystal release 1.19.0 with several new features and bug

--- a/_releases/2026-01-15-1.19.0-released.md
+++ b/_releases/2026-01-15-1.19.0-released.md
@@ -4,13 +4,13 @@ version: 1.19.0
 date: 2026-01-15
 author: ysbaddaden
 highlights:
-- text: "[Compiler flags with values](#Compiler flags now have values)"
+- text: "[Compiler flags with values](#compiler-flags-now-have-values)"
   label: compiler
-- text: "[Execution contexts in final preview including new `Sync` primitives](#Execution contexts)"
+- text: "[Execution contexts in final preview including new `Sync` primitives](#execution-contexts)"
   label: stdlib/runtime
-- text: "[Introduce `Time::Instant`](#time) and [adjust behaviour of monotonic clocks](#Adjust monotonic clocks)"
+- text: "[Introduce `Time::Instant`](#time) and [adjust behaviour of monotonic clocks](#adjust-monotonic-clocks)"
   label: stdlib/time
-- text: "[Process spawning refactor and safer exec handling](#Process)"
+- text: "[Process spawning refactor and safer exec handling](#process)"
   label: stdlib/process
 ---
 

--- a/_sass/pages/_releases.scss
+++ b/_sass/pages/_releases.scss
@@ -34,3 +34,47 @@ table.releases {
     opacity: 0.25;
   }
 }
+
+.release-highlights {
+  &:not(:has(.release-date)) {
+    border-block: 1px solid var(--alabaster);
+    padding-block: var(--padding-sm);
+  }
+
+  > h2:not(:has(.release-date)) {
+    display: none;
+  }
+
+  + .release-highlights {
+    border-block-start: 1px solid var(--alabaster);
+    padding-block-start: var(--block-flow, var(--block-flow-sm));
+  }
+
+  &:has(.release-date) {
+    > h2 {
+      font-size: 1em;
+      font-weight: 500;
+      color: var(--light-text);
+      margin-block-end: var(--padding-sm);
+
+      > .release-date {
+        color: var(--lighter-text);
+        font-weight: 400;
+      }
+    }
+  }
+
+  > ul {
+    padding-inline: 0;
+    margin-block: 0;
+
+    > li {
+      > .highlight {
+        display: flex;
+        align-items: baseline;
+        flex-wrap: wrap;
+        gap: var(--padding-xxs);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a short list with the most important changes for each minor release.
The changes are listed on the top of each release note page. And this also adds an additional page at `/releases/highlights/` which shows the highlights of all releases.

---

**Release page:**

<img width="1257" height="847" alt="image" src="https://github.com/user-attachments/assets/c4db5d01-753c-4b19-8f6c-5c8a75d6f71d" />

---

**Release highlights page:**
<img width="1015" height="906" alt="image" src="https://github.com/user-attachments/assets/123f5a2c-0289-41b9-af49-b020e8d5b9f6" />
