### PR TITLE
Document `aarch64` support on install page

### DIFF
--- a/_data/packages-nightly.yaml
+++ b/_data/packages-nightly.yaml
@@ -15,7 +15,7 @@
 
 - type: crystal
   os: Linux
-  arch: [x86_64]
+  arch: [aarch64, x86_64]
   title: Tarball (`.tar.gz`)
   instructions_href: /install/from_targz/
   archive_href: https://artifacts.crystal-lang.org/dist/crystal-nightly-linux-{{ arch }}.tar.gz

--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -2,7 +2,7 @@
 
 - type: crystal
   os: Linux
-  arch: [x86_64]
+  arch: [aarch64, x86_64]
   title: Installer (DEB &amp; RPM)
   label: Linux installer
   instructions_href: /install/on_linux/#installer
@@ -16,7 +16,7 @@
 
 - type: crystal
   os: Linux
-  arch: [x86_64, x86_64-bundled]
+  arch: [aarch64, aarch64-bundled, x86_64, x86_64-bundled]
   title: Tarball (`.tar.gz`)
   instructions_href: /install/from_targz/
   archive_href: https://github.com/crystal-lang/crystal/releases/download/{{ version }}/crystal-{{ version }}-1-linux-{{ arch }}.tar.gz

--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -36,7 +36,7 @@
 
 - type: system
   os: Linux
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: Apk (Alpine Linux)
   example: |
     ```shell
@@ -110,7 +110,7 @@
 
 - type: community
   os: Linux
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: Nix
   example: '`crystal` package'
   repo_href: https://search.nixos.org/packages?show=crystal&channel=unstable&from=0&size=50&sort=relevance&type=packages&query=crystal
@@ -119,7 +119,7 @@
 
 - type: community
   os: Linux
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: 84codes (DEB &amp; RPM)
   instructions_href: https://packagecloud.io/84codes/crystal
   repo_href: https://packagecloud.io/84codes/crystal
@@ -137,7 +137,7 @@
 
 - type: community
   os: MacOS
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: Homebrew
   example: |
     ```shell
@@ -162,7 +162,7 @@
 
 - type: community
   os: MacOS
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: Nix
   example: '`crystal` package'
   repo_href: https://search.nixos.org/packages?show=crystal&channel=unstable&from=0&size=50&sort=relevance&type=packages&query=crystal
@@ -171,7 +171,7 @@
 
 - type: community
   os: MacOS
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: MacPorts
   example: |
     ```shell
@@ -276,7 +276,7 @@
 
 - type: system
   os: FreeBSD
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: Package
   instructions_href: /install/on_freebsd/#install-package
   example: |
@@ -286,7 +286,7 @@
 
 - type: system
   os: FreeBSD
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: Port
   instructions_href: /install/on_freebsd/#install-port
   example: |
@@ -302,7 +302,7 @@
 
 - type: system
   os: OpenBSD
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: Package
   instructions_href: /install/on_openbsd/#install-package
   example: |
@@ -312,7 +312,7 @@
 
 - type: system
   os: OpenBSD
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: Port
   instructions_href: /install/on_openbsd/#install-port
   example: |
@@ -354,7 +354,7 @@
 
 - type: community
   os: Docker
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: 84codes
   example: |
     ```shell
@@ -367,7 +367,7 @@
 
 - type: crystal
   os: Tools
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: GitHub Actions
   instructions_href: https://crystal-lang.github.io/install-crystal/
   example: |
@@ -379,7 +379,7 @@
 
 - type: community
   os: Tools
-  arch: [x86_64, aarch64]
+  arch: [aarch64, x86_64]
   title: devenv.sh
   example: |
     ```nix

--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -73,7 +73,7 @@
 
 - type: community
   os: Linux
-  arch: [x86_64]
+  arch: [aarch64, x86_64]
   title: Homebrew/Linuxbrew
   example: |
     ```shell
@@ -85,7 +85,7 @@
 
 - type: community
   os: Linux
-  arch: [x86_64]
+  arch: [aarch64, x86_64]
   title: asdf
   instructions_href: /install/from_asdf/
   example: |

--- a/lychee.toml
+++ b/lychee.toml
@@ -15,7 +15,9 @@ exclude_path = [
   "_plugins",
   "_layouts",
   "_includes",
-  "_sass/mixins/_link-with-icon.scss", # lists URL prefixes
+  "_sass/mixins/_link-with-icon.scss", # lists URL prefixes,
+  "_data/packages.yaml", # contains URL templates
+  "_data/packages-nightly.yaml", # contains URL templates
 ]
 
 # Enable the checking of fragments in links.


### PR DESCRIPTION
aarch64 Linux tarballs are available since Crystal 1.19 https://crystal-lang.org/2026/01/15/1.19.0-released/#infra