### PR TITLE
Update pacman command to use -Syu for upgrades

### DIFF
--- a/_data/packages.yaml
+++ b/_data/packages.yaml
@@ -52,7 +52,7 @@
   title: Pacman (Arch Linux)
   example: |
     ```shell
-    pacman -S crystal shards
+    pacman -Syu crystal shards
     ```
   repo_href: https://archlinux.org/packages/extra/x86_64/crystal/
   repo_description: Crystal package on Arch Linux package index


### PR DESCRIPTION
The previous command has the potential to break the entire operating system, since it takes packages that are eventually not compatible with the current (outdated) one.

Rule number one of the rolling club: 
Always update, before you install something new. 🧼 