### PR TITLE
Remove configuration for `first-line-h1` rule

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -26,9 +26,6 @@ no-bare-urls: false
 fenced-code-language: false
 commands-show-output: false
 
-first-line-h1:
-  front_matter_title: "^\\s*(page_)?title\\s*[:=]"
-
 no-alt-text: false
 
 hard_tab:

--- a/_pages/install/nightlies.md
+++ b/_pages/install/nightlies.md
@@ -1,5 +1,5 @@
 ---
-page_title: Nightly Builds
+title: Nightly Builds
 layout: page-wide
 page_class: page--segmented
 description: |


### PR DESCRIPTION
The reason for this special rule was an incorrect frontmatter, which I'm fixing as well.