### PR TITLE
Decrease line height in code blocks

### DIFF
--- a/_sass/base/_typography.scss
+++ b/_sass/base/_typography.scss
@@ -144,6 +144,7 @@ pre > code {
 pre {
   white-space: pre-wrap;
   padding: 1.25em;
+  line-height: var(--line-height-md);
 }
 
 :not(pre) > code,


### PR DESCRIPTION
Code reads better with a smaller line height.

| before | after |
|-|-|
| <img width="1651" height="921" alt="image" src="https://github.com/user-attachments/assets/baea9a2b-18c3-4855-a575-fcdbcdf6c504" /> | <img width="1825" height="930" alt="image" src="https://github.com/user-attachments/assets/b5737d8f-0d44-4b03-82b1-6f50032baac4" /> |
