### PR TITLE
Clarify that the `--threads` CLI option is not a built-in

### DIFF
--- a/_posts/2026-07-12-releasing-execution-contexts.md
+++ b/_posts/2026-07-12-releasing-execution-contexts.md
@@ -48,10 +48,11 @@ parallel = Fiber::ExecutionContext::Parallel.new("MT", maximum: 4)
 parallel.spawn { }
 ```
 
-You can keep it single-threaded if you don't need parallelism.
-Or you can scale it to a fixed or flexible number of maximum parallelism.
-Or let users configure the parallelism at runtime, for example through a command line
-option (e.g. `--threads 8`) or an environment variable (e.g. `THREADS=8`).
+Keep it single‑threaded if parallelism isn’t required. Alternatively, scale it
+to a fixed or dynamically adjustable maximum number of threads. You can let
+users configure parallelism at runtime, by passing a command‑line flag such
+as `--threads 8` or setting an environment variable like `THREADS=8`, for
+example.
 
 Your application, your choice.
 

--- a/_posts/2026-07-12-releasing-execution-contexts.md
+++ b/_posts/2026-07-12-releasing-execution-contexts.md
@@ -48,8 +48,10 @@ parallel = Fiber::ExecutionContext::Parallel.new("MT", maximum: 4)
 parallel.spawn { }
 ```
 
-You can keep it single-threaded if you don't need parallelism, or let users
-determine the parallelism through a `--threads N` argument.
+You can keep it single-threaded if you don't need parallelism.
+Or you can scale it to a fixed or flexible number of maximum parallelism.
+Or let users configure the parallelism at runtime, for example through a command line
+option (e.g. `--threads 8`) or an environment variable (e.g. `THREADS=8`).
 
 Your application, your choice.
 


### PR DESCRIPTION
The previous wording could be understood as if users can always configure parallelism of the default execution context with a CLI option.