### PR TITLE
Enable MD060: Table format

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -70,3 +70,10 @@ no-bare-urls: false
 # MD045 - Add Descriptive Text to Images
 # FIXME: Deferred
 no-alt-text: false
+
+## Table Rules
+
+# MD060 - Table format
+table-format:
+  enabled: true
+  style: aligned-no-space

--- a/_posts/2017-09-25-neuralegion-and-crystal.md
+++ b/_posts/2017-09-25-neuralegion-and-crystal.md
@@ -43,13 +43,13 @@ We want to point out that this article is solely our personal experience and opi
 
 Here is a comparison between some of the parameters which were important to us:
 
-Ruby|Crystal
-:---: | :---:
-Dynamically typed | Statically typed
-Nil reference errors in runtime | Nil reference error checks at compile time
-Vast amount of existing libraries | Relatively small amount of existing libraries
-Limited runtime performance | Fast runtime performance
-Runs in virtual machine | Compiled native code
+|               Ruby                |                    Crystal                    |
+|:---------------------------------:|:---------------------------------------------:|
+|         Dynamically typed         |               Statically typed                |
+|  Nil reference errors in runtime  |  Nil reference error checks at compile time   |
+| Vast amount of existing libraries | Relatively small amount of existing libraries |
+|    Limited runtime performance    |           Fast runtime performance            |
+|      Runs in virtual machine      |             Compiled native code              |
 
 ## Useful Links
 

--- a/_posts/2017-12-19-this-is-not-a-new-years-resolution.md
+++ b/_posts/2017-12-19-this-is-not-a-new-years-resolution.md
@@ -19,12 +19,12 @@ The end of the year has been much slower than the beginning, as we had to cope w
 
 We have now gone through a collective estimate and have a solid plan to reach 1.0.
 
-| Area               | Details | ~Effort in hours |
-|--------------------|---------|------------------|
-| Distributions      | Release builds, distro packages, Docker images, etc | 120 |
-| Multi-threading    | Rework the fiber scheduler to handle multiple threads in parallel | 680 |
-| Better debugging   | Develop compiler and runtime support for a reasonable debugging experience | 680 |
-| Language semantics | Consider interfaces, generics, macros and interactions between all of them. Remove inessential or redundant language features. | 600 |
+| Area               | Details                                                                                                                        | ~Effort in hours |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------|------------------|
+| Distributions      | Release builds, distro packages, Docker images, etc                                                                            | 120              |
+| Multi-threading    | Rework the fiber scheduler to handle multiple threads in parallel                                                              | 680              |
+| Better debugging   | Develop compiler and runtime support for a reasonable debugging experience                                                     | 680              |
+| Language semantics | Consider interfaces, generics, macros and interactions between all of them. Remove inessential or redundant language features. | 600              |
 
 Come January, we will restart our work on Crystal in the areas above and will continue to invest at least 2x the hours covered with donations. Please help us ~~[spread the word](https://salt.bountysource.com/teams/crystal-lang)~~ so that we can get to this first production-ready release as soon as possible.
 

--- a/_releases/2024-04-09-1.12.0-released.md
+++ b/_releases/2024-04-09-1.12.0-released.md
@@ -46,7 +46,7 @@ _Thanks [@HertzDevil]_
 All current uses of `on_interrupt` can be replaced by `on_terminate` with the effect of responding to more termination triggers.
 
 | Method         | Unix                             | Windows                                                                                                                                                 |
-| -------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------|----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `on_terminate` | `SIGINT`, `SIGHUP` and `SIGTERM` | <kbd>Ctrl</kbd> + <kbd>C</kbd>, <kbd>Ctrl</kbd> + <kbd>Break</kbd>, terminal close, windows logoff  and shutdown signals sent to a console application. |
 | `on_interrupt` | `SIGINT`                         | <kbd>Ctrl</kbd> + <kbd>C</kbd> and <kbd>Ctrl</kbd> + <kbd>Break</kbd> signals sent to a console application                                             |
 

--- a/_style_guide/typography/table.md
+++ b/_style_guide/typography/table.md
@@ -3,9 +3,9 @@ title: Table
 type: typography
 ---
 
-| Operator | Description | Example | Overloadable | Associativity |
-|---|---|---|---|---|
-| `+`  | positive | `+1` | [yes](/) | right |
-| `&+` | wrapping positive | `&+1` | yes | right |
-| `-`  | negative | `-1` | yes | right |
-| `&-` | wrapping negative | `&-1` | yes | right |
+| Operator | Description       | Example | Overloadable | Associativity |
+|----------|-------------------|---------|--------------|---------------|
+| `+`      | positive          | `+1`    | [yes](/)     | right         |
+| `&+`     | wrapping positive | `&+1`   | yes          | right         |
+| `-`      | negative          | `-1`    | yes          | right         |
+| `&-`     | wrapping negative | `&-1`   | yes          | right         |


### PR DESCRIPTION
This table format style improves readability of the markdown source code. 

We're using it in crystal-book already(https://github.com/crystal-lang/crystal-book/pull/932)

> This table format aligns all pipe characters at the same column, which makes for a tabular layout even in the source code.
It's not strictly better than the previous compact format. It certainly causes longer line lengths.
But I think the alignment improves readability. The cost for that is sometimes you need horizontal scroll. But I prefer that clarity over the tightly compressed text.