### PR TITLE
Format code blocks

### DIFF
--- a/_posts/2013-07-10-hello-world.md
+++ b/_posts/2013-07-10-hello-world.md
@@ -16,7 +16,7 @@ But if you feel like it, you can also use some object oriented programming:
 
 ```crystal
 class Greeter
-  def initialize(@name : String )
+  def initialize(@name : String)
   end
 
   def salute

--- a/_posts/2013-09-04-happy-birthday-crystal.md
+++ b/_posts/2013-09-04-happy-birthday-crystal.md
@@ -44,7 +44,7 @@ They come in many flavors, like in Ruby, and they also support interpolation.
 
 ```crystal
 a = "World"
-b = "Hello #{a}" #=> "Hello World"
+b = "Hello #{a}" # => "Hello World"
 ```
 
 We still need to decide what's the best way to deal with different encodings, so this
@@ -116,14 +116,14 @@ end
 def foo(x : Float)
 end
 
-def foo(x)
+def foo(x, &)
   yield
 end
 
-foo 1, 1      # Invokes foo 1
-foo 1         # Invokes foo 2
-foo 1.5       # Invokes foo 3
-foo(1) { }    # Invokes foo 4
+foo 1, 1   # Invokes foo 1
+foo 1      # Invokes foo 2
+foo 1.5    # Invokes foo 3
+foo(1) { } # Invokes foo 4
 ```
 
 Contrast this with having to check **at runtime** the number of arguments of the method,
@@ -175,11 +175,11 @@ class Foo(T)
   end
 end
 
-foo = Foo.new(1)    # T is inferred to be an Int32, and foo is a Foo(Int32)
-foo.value.abs       # Ok
+foo = Foo.new(1) # T is inferred to be an Int32, and foo is a Foo(Int32)
+foo.value.abs    # Ok
 
 foo2 = Foo.new('a') # T is inferred to be a Char, and foo2 is a Foo(Char)
-foo2.value.ord            # Ok
+foo2.value.ord      # Ok
 
 # You can also explicitly specify the generic type variable
 foo3 = Foo(String).new("hello")
@@ -190,9 +190,9 @@ literals. When elements are specified, the generic type variables are inferred.
 If no element is specified, you have to tell Crystal the generic type variables.
 
 ```crystal
-a = [1, 2, 3]            # a is an Array(Int32)
-b = [1, 1.5, 'a']        # b is an Array(Int32 | Float64 | Char)
-c = [] of String         # c is an Array(String), same as doing Array(String).new
+a = [1, 2, 3]     # a is an Array(Int32)
+b = [1, 1.5, 'a'] # b is an Array(Int32 | Float64 | Char)
+c = [] of String  # c is an Array(String), same as doing Array(String).new
 
 d = {1 => 2, 3 => 4}     # d is a Hash(Int32, Int32)
 e = {} of String => Bool # e is a Hash(String, Bool), same as doing Hash(String, Bool).new
@@ -259,9 +259,9 @@ Regular expressions are implemented, for now, with C bindings to the PCRE librar
 `Regexp` is entirely written in Crystal.
 
 ```crystal
-"foobarbaz" =~ /(.+)bar(.+)/ #=> 0
-$1                           #=> "foo"
-$2                           #=> "baz
+"foobarbaz" =~ /(.+)bar(.+)/ # => 0
+$1                           # => "foo"
+$2                           # => "baz
 ```
 
 ## Ranges
@@ -320,7 +320,7 @@ end
 
 foo do |x|
   # Invokes "abs" on -1
-  puts abs + x #=> 3
+  puts abs + x # => 3
 end
 ```
 

--- a/_posts/2013-09-15-to-proc.md
+++ b/_posts/2013-09-15-to-proc.md
@@ -79,25 +79,25 @@ is available for giving it a new meaning. So in Crystal we chose to use this syn
 With this little change, we can pass arguments to the method very easily:
 
 ```crystal
-[10, 20, 30].map &.modulo(3) #=> [1, 2, 0] ... but only in Crystal ;-)
+[10, 20, 30].map &.modulo(3) # => [1, 2, 0] ... but only in Crystal ;-)
 ```
 
 Not only that, but you can also write this:
 
 ```crystal
-[1, 20, 300].map &.to_s.size #=> 1, 2, 3
+[1, 20, 300].map &.to_s.size # => 1, 2, 3
 ```
 
 Or this:
 
 ```crystal
-[[1, -2], [-3, -4]].map(&.map(&.abs)) #=> [[1, 2], [3, 4]]
+[[1, -2], [-3, -4]].map(&.map(&.abs)) # => [[1, 2], [3, 4]]
 ```
 
 And of course this:
 
 ```crystal
-[1, 2, 3, 4].map &.**(2) #=> [1, 4, 9, 16]
+[1, 2, 3, 4].map &.**(2) # => [1, 4, 9, 16]
 ```
 
 The best thing is that this is just a syntax rewrite without any performance penalty.

--- a/_posts/2014-04-27-type-inference-rules.md
+++ b/_posts/2014-04-27-type-inference-rules.md
@@ -20,10 +20,10 @@ control structures, like `if`, `while`, and blocks. Then we'll talk about the sp
 Literals have a type of their own, known by the compiler:
 
 ```crystal
-true     # Boolean
-1        # Int32
-"hello"  # String
-1.5      # Float64
+true    # Boolean
+1       # Int32
+"hello" # String
+1.5     # Float64
 ```
 
 ### C functions
@@ -93,7 +93,7 @@ you can assign multiple times to a variable:
 a = 1       # a is Int32
 a.abs       # ok, Int32 has a method 'abs'
 a = "hello" # a is now String
-a.size    # ok, String has a method 'size'
+a.size      # ok, String has a method 'size'
 ```
 
 To achieve this, the compiler remembers which expression was the last one assigned
@@ -201,9 +201,9 @@ while some_condition
   a           # here a is actually Int32 or String
   a = false   # here a is Bool
   a = "hello" # here a is String
-  a.size    # ok, a is String
+  a.size      # ok, a is String
 end
-a             # here a is Int32 or String
+a # here a is Int32 or String
 ```
 
 Some other things to consider inside a `while` are `break` and `next`. A `break`
@@ -212,14 +212,14 @@ makes the types right before the break add to the type at the exit of the `while
 ```crystal
 a = 1
 while some_condition
-  a             # here a is Int32 or Bool
+  a # here a is Int32 or Bool
   if some_other_condition
     a = "hello" # we break, so at the exit a can also be String
     break
   end
-  a = false     # here a is Bool
+  a = false # here a is Bool
 end
-a               # here a is Int32 or String or Bool
+a # here a is Int32 or String or Bool
 ```
 
 A `next` adds the type to the beginning of the `while`:
@@ -227,14 +227,14 @@ A `next` adds the type to the beginning of the `while`:
 ```crystal
 a = 1
 while some_condition
-  a             # here a is Int32 or String or Bool
+  a # here a is Int32 or String or Bool
   if some_other_condition
     a = "hello" # we next, so in the next iteration a can be String
     next
   end
-  a = false     # here a is Bool
+  a = false # here a is Bool
 end
-a               # here a is Int32 or String or Bool
+a # here a is Int32 or String or Bool
 ```
 
 ### Blocks
@@ -359,7 +359,7 @@ We can define another method, `try`:
 
 ```crystal
 class Object
-  def try
+  def try(&)
     yield self
   end
 end
@@ -387,7 +387,7 @@ inside the `then` branch:
 ```crystal
 a = some_condition ? 1 : nil # a is Int32 or Nil
 if a
-  a.abs                      # a is Int32
+  a.abs # a is Int32
 end
 ```
 
@@ -398,11 +398,11 @@ whatever type `a` has in the `else` branch. For example:
 ```crystal
 a = some_condition ? 1 : nil
 if a
-  a.abs   # ok, here a is Int32
+  a.abs # ok, here a is Int32
 else
-  a = 1   # here a is Int32
+  a = 1 # here a is Int32
 end
-a.abs     # ok, a can only be Int32 here
+a.abs # ok, a can only be Int32 here
 ```
 
 Just like a programmer expects the above to always work in Ruby (never raise an

--- a/_posts/2015-03-04-internals.md
+++ b/_posts/2015-03-04-internals.md
@@ -148,7 +148,7 @@ A Pointer is a generic type that represents a typed pointer to some memory locat
 ```crystal
 x = Pointer(Int32).malloc(1_u64)
 x.value = 1
-x.value #=> 1
+x.value # => 1
 ```
 
 If you look at the generated LLVM IR code you will see a bunch of code. First, `x` is represented like this:
@@ -236,7 +236,7 @@ end
 The nice thing about enums is that you can print them and you get their name, not their value:
 
 ```crystal
-puts Color::Green #=> Green
+puts Color::Green # => Green
 ```
 
 This is done in a different way than with Symbol, [using compile-time reflection and macros](https://github.com/crystal-lang/crystal/blob/965d6959163717d72cd3703159d60004ebf7f266/src/enum.cr#L4).
@@ -544,7 +544,7 @@ end
 class Baz < Bar
 end
 
-Baz.new.foo #=> 1
+Baz.new.foo # => 1
 ```
 
 Wow, a big class hierarchy and even an included module, and two definitions for `foo`. By looking at the code,
@@ -653,8 +653,11 @@ Consider this class hierarchy:
 
 ```crystal
 class Foo; end
+
 class Bar < Foo; end
+
 class Baz < Bar; end
+
 class Qux < Bar; end
 ```
 

--- a/_posts/2015-04-01-auto.md
+++ b/_posts/2015-04-01-auto.md
@@ -26,7 +26,7 @@ class String
   end
 end
 
-"hello".succ #=> "hellp"
+"hello".succ # => "hellp"
 ```
 
 The first thing you need to know is that `String#succ` is not in Crystal's standard library. In the code
@@ -84,8 +84,8 @@ list = LinkedList(Char).new
 list.push 'a'
 list.push 'b'
 list.push 'c'
-puts list.size #=> 3
-puts list        #=> ['a', 'b', 'c']
+puts list.size # => 3
+puts list      # => ['a', 'b', 'c']
 ```
 
 So the **auto** macro actually checks whether the received AST node is a class or method. For the class

--- a/_posts/2015-08-24-its-a-typeof-magic.md
+++ b/_posts/2015-08-24-its-a-typeof-magic.md
@@ -96,8 +96,8 @@ Little did we know that `typeof` would bring a lot of power to the language.
 One obvious use-case of typeof is to ask the compiler the inferred type of an expression. For example:
 
 ```crystal
-puts typeof(1) #=> Int32
-puts typeof([1, 2, 3].map &.to_s) #=> Array(String)
+puts typeof(1)                    # => Int32
+puts typeof([1, 2, 3].map &.to_s) # => Array(String)
 ```
 
 At this point you might think that `typeof(exp)` is similar to `exp.class`. However,
@@ -105,15 +105,15 @@ the first gives you the compile-time type, while the second gives you the runtim
 
 ```crystal
 exp = rand(0..1) == 0 ? 'a' : true
-puts typeof(exp) #=> Char | Bool
-puts exp.class   #=> Char (or Bool, depending on the chosen random value)
+puts typeof(exp) # => Char | Bool
+puts exp.class   # => Char (or Bool, depending on the chosen random value)
 ```
 
 Another simple use case is to create a type based on another object's type:
 
 ```crystal
 hash = {1 => 'a', 2 => 'b'}
-other_hash = typeof(hash).new #:: Hash(Int32, Char)
+other_hash = typeof(hash).new # :: Hash(Int32, Char)
 ```
 
 In this way we can avoid repeating or hardcoding a type name.
@@ -145,8 +145,8 @@ end
 If `exp` is `Nil` we raise an exception, otherwise we return `exp`. Let's check its type:
 
 ```crystal
-puts typeof(not_nil(1))   #=> Int32
-puts typeof(not_nil(nil)) #=> NoReturn
+puts typeof(not_nil(1))   # => Int32
+puts typeof(not_nil(nil)) # => NoReturn
 ```
 
 Thanks to the way [if var.is_a?(...)](http://crystal-lang.org/docs/syntax_and_semantics/if_varis_a.html) works,
@@ -159,8 +159,8 @@ Let's try and give `not_nil` something that's a union type:
 
 ```crystal
 element = rand(0..1) == 0 ? 1 : nil
-puts typeof(element)          #=> Int32 | Nil
-puts typeof(not_nil(element)) #=> Int32
+puts typeof(element)          # => Int32 | Nil
+puts typeof(not_nil(element)) # => Int32
 ```
 
 Note that the `NoReturn` type is gone: the "expected" type of the last expression would be `Int32 | NoReturn`, that
@@ -183,11 +183,11 @@ class Array
 end
 
 ary = [1, nil, 2, nil, 3]
-puts typeof(ary)       #=> Array(Int32 | Nil)
+puts typeof(ary) # => Array(Int32 | Nil)
 
 compacted = ary.compact
-puts compacted         #=> [1, 2, 3]
-puts typeof(compacted) #=> Array(Int32)
+puts compacted         # => [1, 2, 3]
+puts typeof(compacted) # => Array(Int32)
 ```
 
 The magical line is the first one in the method:
@@ -214,11 +214,11 @@ Note that this has to work recursively. Let's see some expected behaviour:
 
 ```crystal
 ary1 = [1, [2, [3], 'a']]
-puts typeof(ary1)             #=> Array(Int32 | Array(Int32 | Array(Int32) | Char))
+puts typeof(ary1) # => Array(Int32 | Array(Int32 | Array(Int32) | Char))
 
 ary1_flattened = ary1.flatten
-puts ary1_flattened           #=> [1, 2, 3, 'a']
-puts typeof(ary1_flattened)   #=> Array(Int32 | Char)
+puts ary1_flattened         # => [1, 2, 3, 'a']
+puts typeof(ary1_flattened) # => Array(Int32 | Char)
 ```
 
 Like before, let's start by writing a method whose type will have the type that we need for the flattened
@@ -233,9 +233,9 @@ def flatten_type(object)
   end
 end
 
-puts typeof(flatten_type(1))                          #=> Int32
-puts typeof(flatten_type([1, [2]]))                   #=> Int32
-puts typeof(flatten_type([1, [2, ['a', 'b']]]))       #=> Int32 | Char
+puts typeof(flatten_type(1))                    # => Int32
+puts typeof(flatten_type([1, [2]]))             # => Int32
+puts typeof(flatten_type([1, [2, ['a', 'b']]])) # => Int32 | Char
 ```
 
 The method is simple: if the object is an array, we want the flatten type of any of its elements. Otherwise,

--- a/_posts/2015-09-05-tools.md
+++ b/_posts/2015-09-05-tools.md
@@ -54,11 +54,11 @@ class B
 end
 
 def use_foo(o)
-  o.foo           # put the cursor in this #foo call
+  o.foo # put the cursor in this #foo call
 end
 
 use_foo(A.new)
-use_foo(B.new)    # if removed, line 7 won't be an implementation of line 12
+use_foo(B.new) # if removed, line 7 won't be an implementation of line 12
 ```
 
 ## Down a macro hole
@@ -71,7 +71,7 @@ class Person
 end
 
 p = Person.new
-p.name = "John"   # put the cursor in over #name= call
+p.name = "John" # put the cursor in over #name= call
 ```
 
 ```console
@@ -122,7 +122,6 @@ The tool is available in command line manner.
 ```crystal
 a = "a string"
 b = 1
-
 ```
 
 ```console

--- a/_posts/2016-09-09-a-story-of-compromises-and-types.md
+++ b/_posts/2016-09-09-a-story-of-compromises-and-types.md
@@ -14,8 +14,8 @@ Let's play with an immutable Queue type. We want to:
 So something like this:
 
 ```crystal
-q = build_queue  # q = {}
-new_q = q.push 2 # q = {2}
+q = build_queue      # q = {}
+new_q = q.push 2     # q = {2}
 e, old_q = new_q.pop # e = 2, q = {}
 ```
 
@@ -72,11 +72,11 @@ q.pop # => Compile Error :-) EmptyQueue does not have EmptyQueue#pop
 But is it really useful?
 
 ```crystal
-q0 = EmptyQueue.new   # q0 = {}
-q1 = q0.push 1        # q1 = {1}
-q2 = q1.push 2        # q2 = {2, 1}
-e, q3 = q2.pop        # q3 = {1}, e = 2
-e, q4 = q3.pop        # => Compile Error :-( , but *we* know q3 is not empty...
+q0 = EmptyQueue.new # q0 = {}
+q1 = q0.push 1      # q1 = {1}
+q2 = q1.push 2      # q2 = {2, 1}
+e, q3 = q2.pop      # q3 = {1}, e = 2
+e, q4 = q3.pop      # => Compile Error :-( , but *we* know q3 is not empty...
 ```
 
 The compile error is because `typeof(q3) :: EmptyQueue | Queue`.

--- a/_posts/2017-01-06-the-charly-programming-language.md
+++ b/_posts/2017-01-06-the-charly-programming-language.md
@@ -19,7 +19,7 @@ Charly is a dynamically typed and object-oriented programming language. The synt
 Below is an implementation of the [Bubblesort algorithm](https://en.wikipedia.org/wiki/Bubblesort) written in Charly. It is part of the standard library which is also written in Charly.
 
 ```javascript
-  func sort(sort_function) {
+func sort(sort_function) {
     const sorted = @copy()
 
     let left

--- a/_posts/2018-01-08-top-5-reasons-for-ruby-ists-to-use-crystal.md
+++ b/_posts/2018-01-08-top-5-reasons-for-ruby-ists-to-use-crystal.md
@@ -28,8 +28,8 @@ end
 
 ```crystal
 module Hamming
-  def self.distance(a,b)
-    a.chars.zip(b.chars).count{|first, second| first != second }
+  def self.distance(a, b)
+    a.chars.zip(b.chars).count { |first, second| first != second }
   end
 end
 ```
@@ -53,8 +53,8 @@ Crystal is a compiled language and checks all your method inputs and outputs at 
 Let's revisit the `Year::leap?` example from above. In Ruby, what happens when the input isn't an integer?
 
 ```crystal
-Year.leap?("2016") #=> false
-Year.leap?(Date.new(2016, 1, 1)) #=> undefined method `%' for #<Date: 2016-01-01 ... >
+Year.leap?("2016")               # => false
+Year.leap?(Date.new(2016, 1, 1)) # => undefined method `%' for #<Date: 2016-01-01 ... >
 ```
 
 For a `String` we get the wrong answer, for a `Date` we get a runtime exception. Fixing things in Ruby would require at least one `is_a?` statement:
@@ -81,9 +81,9 @@ We get helpful messages **at compile time**, rather than runtime:
 
 ```crystal
 Year.leap?("2016")
-Error in line 10: no overload matches 'Year.leap?' with type String
-Overloads are:
- - Year.leap?(year : Int)
+# Error in line 1: no overload matches 'Year.leap?' with type String
+# Overloads are:
+# - Year.leap?(year : Int)
 ```
 
 If we want to add support for `Time` (think `DateTime` in Ruby) in our module, we can overload `Year::leap?`:
@@ -131,12 +131,10 @@ Have you ever read Ruby’s source code? Tried to figure out how some `Enumerabl
 [Ruby’s Implementation of `Enumerable#all?`](https://github.com/ruby/ruby/blob/v2_5_0/enum.c#L1215)
 
 ```c
-static VALUE
-enum_all(int argc, VALUE *argv, VALUE obj)
-{
-    struct MEMO *memo = MEMO_ENUM_NEW(Qtrue);
-    rb_block_call(obj, id_each, 0, 0, ENUMFUNC(all), (VALUE)memo);
-    return memo->v1;
+static VALUE enum_all(int argc, VALUE *argv, VALUE obj) {
+  struct MEMO *memo = MEMO_ENUM_NEW(Qtrue);
+  rb_block_call(obj, id_each, 0, 0, ENUMFUNC(all), (VALUE)memo);
+  return memo->v1;
 }
 ```
 
@@ -145,7 +143,7 @@ How long does it take to figure out what that code is doing? If you've never wor
 Compare that to [Crystal's implementation of `Enumerable#all?`](https://github.com/crystal-lang/crystal/blob/v0.24.1/src/enumerable.cr#L46)
 
 ```crystal
-def all?
+def all?(&)
   each { |e| return false unless yield e }
   true
 end

--- a/_posts/2018-01-25-amber-crystalizing-rails-and-phoenix.md
+++ b/_posts/2018-01-25-amber-crystalizing-rails-and-phoenix.md
@@ -114,10 +114,10 @@ That's right. Thanks to the speed of Crystal, Amber can complete an entire reque
 For a real sample of speed, this excerpt is from a basic Read route such as this:
 
 ```crystal
-  def profile
-    user = current_user
-    render "show.slang"
-  end
+def profile
+  user = current_user
+  render "show.slang"
+end
 ```
 
 ```log

--- a/_posts/2018-02-06-lucky-with-crystal.md
+++ b/_posts/2018-02-06-lucky-with-crystal.md
@@ -82,7 +82,7 @@ end
 
 _Lucky will catch a bug for you and give you a helpful message to guide you in the right direction:_
 
-```crystal
+```txt
 SamlSignIns::Create returned Lucky::Response | Nil, but it must return a Lucky::Response.
 
 Try this...

--- a/_posts/2019-05-08-formatting-pretty-numbers-for-humans.md
+++ b/_posts/2019-05-08-formatting-pretty-numbers-for-humans.md
@@ -23,10 +23,10 @@ It allows printing numbers in a customizable format, that can represent the way 
 Numbers can be formatted using configurable decimal separator and thousands delimiter:
 
 ```crystal
-123_456.789.format('.', ',')   # => "123,456.789"
-123_456.789.format(',', '.')   # => "123.456,789"
-123_456.789.format(',', ' ')   # => "123 456,789"
-123_456.789.format(',', '\'')  # => "123'456,789"
+123_456.789.format('.', ',')  # => "123,456.789"
+123_456.789.format(',', '.')  # => "123.456,789"
+123_456.789.format(',', ' ')  # => "123 456,789"
+123_456.789.format(',', '\'') # => "123'456,789"
 ```
 
 The number of digits in a thousands group is also configurable. This works for example for Chinese numbers grouped by tenthousands:

--- a/_posts/2021-12-29-crystal-i.md
+++ b/_posts/2021-12-29-crystal-i.md
@@ -49,7 +49,7 @@ Invoking `crystal i write_hello.cr` will produce the file `/tmp/hello` and print
 
 This command opens an interactive crystal session (REPL) similar to `irb` from Ruby. In this session we can write a command and get its result:
 
-```crystal
+```pry
 icr:1:0> File.read_lines("/tmp/hello")
 => ["Hello from the interpreter!"]
 ```
@@ -68,7 +68,7 @@ In any of these two modes, you can use `debugger` in your code to debug it at th
 
 For instance, if we add `debugger` between the `write` and the `puts` in `write_hello.cr`, we get the following after interpreting the file:
 
-```crystal
+```pry
 From: /tmp/write_hello.cr:3:6 <Program>#/tmp/write_hello.cr:
 
     1: File.write("/tmp/hello", "Hello from the interpreter!")
@@ -80,7 +80,7 @@ pry>
 
 And if we `step`, we can see the method form the standard library being called:
 
-```crystal
+```pry
 pry> step
 From: /Users/beta/projects/crystal/crystal/src/kernel.cr:385:1 <Program>#puts:
 

--- a/_posts/2023-03-06-reveal-type-in-crystal.md
+++ b/_posts/2023-03-06-reveal-type-in-crystal.md
@@ -146,7 +146,7 @@ end
 
 If we try to get the compile-time type of the expression `t` we will stumble on the infamous “can't execute TypeOf in a macro”.
 
-```console
+```text
 {% raw %}
 In program.ign.cr:4:26
 
@@ -253,7 +253,7 @@ def dig_first(xs)
   end
 end
 
-dig_first([[1,[2],3]])
+dig_first([[1, [2], 3]])
 ```
 
 ```console
@@ -330,9 +330,11 @@ In the `reveal_type` macro we needed to show the expression and its location. Th
 
 ```crystal
 {% raw %}
+
 macro reveal_type(t)
   {%- t.raise "Lorem ipsum" %}
 end
+
 {% endraw %}
 ```
 

--- a/_releases/2014-06-19-crystal-0.1.0-released.md
+++ b/_releases/2014-06-19-crystal-0.1.0-released.md
@@ -65,8 +65,8 @@ The language features that we consider make Crystal attractive and efficient are
 You can create an argument-less function literal like this:
 
 ```crystal
-f = ->{ 1 + 2 }
-puts f.call #=> 3
+f = -> { 1 + 2 }
+puts f.call # => 3
 ```
 
 The return type is automatically inferred.
@@ -75,7 +75,7 @@ If you want a function literal with arguments, you need to specify their types:
 
 ```crystal
 f = ->(x : Int32) { x + 1 }
-puts f.call(2) #=> 3
+puts f.call(2) # => 3
 ```
 
 A function literal has access to the environment where it was created. For example:
@@ -84,10 +84,10 @@ A function literal has access to the environment where it was created. For examp
 a = 1
 
 f = ->(x : Int32) { x + a }
-puts f.call(2) #=> 3
+puts f.call(2) # => 3
 
 a = 10
-puts f.call(2) #=> 12
+puts f.call(2) # => 12
 ```
 
 That is, it can form a [closure](http://en.wikipedia.org/wiki/Closure_(computer_programming)).
@@ -105,28 +105,28 @@ class Foo
   end
 
   def x_proxy
-    ->{ @x }
+    -> { @x }
   end
 end
 
 foo = Foo.new(1)
 proxy = foo.x_proxy
-puts proxy.call #=> 1
+puts proxy.call # => 1
 
 foo.x = 10
-puts proxy.call #=> 10
+puts proxy.call # => 10
 ```
 
 A function literal can be passed as a block to a method using an ampersand (`&`):
 
 ```crystal
-def foo
+def foo(&)
   yield 1
 end
 
 f = ->(x : Int32) { x + 2 }
 value = foo &f
-puts value #=> 3
+puts value # => 3
 ```
 
 You can also get a function pointer to an existing method. In this case, you must
@@ -138,7 +138,7 @@ def foo(x)
 end
 
 f = ->foo(Int32)
-puts f.call(2) #=> 3
+puts f.call(2) # => 3
 ```
 
 You can also get a function pointer to a class' instance method:
@@ -168,7 +168,7 @@ end
 
 a = 1
 f = foo { |x| x + a }
-puts f.call(2) #=> 3
+puts f.call(2) # => 3
 ```
 
 Note that in this last form a closure is automatically created if needed: in the last
@@ -187,15 +187,15 @@ def foo(&block : Int32 -> U)
 end
 
 f = foo { |x| x + 1 }
-puts f.call(2) #=> 3
+puts f.call(2) # => 3
 
 g = foo { |x| x.to_s }
-p g.call(2) #=> "2"
+p g.call(2) # => "2"
 
 # Or also:
 
 h = foo &.to_s
-p h.call(2) #=> "2"
+p h.call(2) # => "2"
 ```
 
 (A small note on free variables: right now the compiler figures out that `U` is a free variable because there's
@@ -205,12 +205,12 @@ method's signature, like it is done in other languages like Java, C#, Rust, D, e
 If you don't care about the return value of a passed block, you can omit the block's return type:
 
 ```crystal
-def foo(&block : Int32 -> )
+def foo(&block : Int32 ->)
   block
 end
 
 f = foo { |x| x + 1 }
-f.call(2) #=> (void)
+f.call(2) # => (void)
 ```
 
 This last form allows for a very nice and comfortable way to specify callbacks:
@@ -256,7 +256,7 @@ a = 0
 10.times do |i|
   a += i
 end
-puts a #=> 45
+puts a # => 45
 ```
 
 is exactly the same as the following code, only nicer:
@@ -268,7 +268,7 @@ while i < 10
   a += i
   i += 1
 end
-puts a #=> 45
+puts a # => 45
 ```
 
 That way Crystal has zero-cost iteration abstraction, while still being able to do stuff like this:
@@ -316,8 +316,8 @@ macro generate_methods(names)
 end
 
 generate_methods [foo, bar, baz]
-foo #=> 0
-baz #=> 2
+foo # => 0
+baz # => 2
 bar # (compile-time error, `bar` undefined)
 ```
 
@@ -389,8 +389,8 @@ Tuples are a fixed-size list where each element can have a different type:
 
 ```crystal
 tuple = {1, "hello"}
-puts tuple[0] #=> 1
-puts tuple[1] #=> hello
+puts tuple[0] # => 1
+puts tuple[1] # => hello
 ```
 
 Tuples can be decomposed on assignment:
@@ -410,8 +410,8 @@ def name_and_age
 end
 
 name, age = name_and_age
-puts name.size #=> 7
-puts age.to_i    #=> 1
+puts name.size # => 7
+puts age.to_i  # => 1
 ```
 
 Note that returning an Array won't work, because an Array mixes the types of everything you put in it:
@@ -422,7 +422,7 @@ def name_and_age
 end
 
 name, age = name_and_age
-puts name.size #=> undefined method 'size' for Float64
+puts name.size # => undefined method 'size' for Float64
 puts age.to_i
 ```
 
@@ -431,7 +431,7 @@ the `Enumerable` module:
 
 ```crystal
 nums = {1, 2, 3.5}
-puts nums.size #=> 3
+puts nums.size # => 3
 nums.each do |value|
   puts value
 end

--- a/_releases/2014-12-04-crystal-0.5.4-released.md
+++ b/_releases/2014-12-04-crystal-0.5.4-released.md
@@ -32,12 +32,12 @@ require "json"
 class Person
   json_mapping({
     name: String,
-    age: Int32
+    age:  Int32,
   })
 end
 
 person = Person.from_json %({"name": "John", "age": 30})
-p person #=> #<Person:0x10220CF20 @name="John", @age=30>
+p person # => #<Person:0x10220CF20 @name="John", @age=30>
 ```
 
 Please read the [Changelog](https://github.com/crystal-lang/crystal/releases/tag/0.5.4) for all the details.

--- a/_releases/2015-02-07-crystal-0.5.9-released.md
+++ b/_releases/2015-02-07-crystal-0.5.9-released.md
@@ -28,7 +28,7 @@ continue making the language more solid, stable and consistent.
 Then [zamith](https://github.com/zamith) has enhanced array literals of strings:
 
 ```crystal
-%w(one two three) #=> ["one", "two", "three"]
+%w(one two three) # => ["one", "two", "three"]
 
 # But these ones didn't work before 0.5.9
 %w<one two three>

--- a/_releases/2016-03-07-crystal-0.13.0-released.md
+++ b/_releases/2016-03-07-crystal-0.13.0-released.md
@@ -82,7 +82,7 @@ Now you can generate a random float between 0 and `max`, or between a given floa
 thanks to [AlexWayfer](https://github.com/AlexWayfer):
 
 ```crystal
-puts rand(1.5) # => 0.0369659
+puts rand(1.5)      # => 0.0369659
 puts rand(1.5..2.5) # => 1.68439
 ```
 

--- a/_releases/2016-06-14-crystal-0.18.0-released.md
+++ b/_releases/2016-06-14-crystal-0.18.0-released.md
@@ -79,7 +79,7 @@ and [select](http://ruby-doc.org/core-2.3.1/Enumerable.html#method-i-select). Fo
 class Foo
   include Enumerable
 
-  def each
+  def each(&)
     yield 1
     yield 2
     yield 3
@@ -111,9 +111,9 @@ One would think that `Hash` implements `each` like this:
 
 ```crystal
 class Hash
-  def each
+  def each(&)
     # for each key and value
-        yield key, value
+    yield key, value
     # end
   end
 end
@@ -159,7 +159,7 @@ The answer is that if a method yields an array, and the block specifies more tha
 one argument, the array is unpacked. For example:
 
 ```crystal
-def foo
+def foo(&)
   yield [1, 2]
 end
 
@@ -191,11 +191,11 @@ Splats now work in yield and block arguments. This makes it trivial to forward
 block arguments to another method:
 
 ```crystal
-def foo
+def foo(&)
   yield 1, 2
 end
 
-def bar
+def bar(&)
   foo do |*args|
     yield *args
   end

--- a/_releases/2016-11-22-crystal-0.20.0-released.md
+++ b/_releases/2016-11-22-crystal-0.20.0-released.md
@@ -133,7 +133,7 @@ Where previously a program behaved like this:
 
 ```crystal
 "RubyConf 2016 at São Paulo was awesome!".upcase
-  # => "RUBYCONF 2016 AT SãO PAULO WAS AWESOME!"
+# => "RUBYCONF 2016 AT SãO PAULO WAS AWESOME!"
 ```
 
 (notice the small 'ã')
@@ -142,7 +142,7 @@ Now it behaves correctly:
 
 ```crystal
 "RubyConf 2016 at São Paulo was awesome!".upcase
-  # => "RUBYCONF 2016 AT SÃO PAULO WAS AWESOME!"
+# => "RUBYCONF 2016 AT SÃO PAULO WAS AWESOME!"
 ```
 
 This of course works for any language, and even some complex ligatures are
@@ -150,7 +150,7 @@ handled:
 
 ```crystal
 "ЙЦУКЕНГШЩЗХЪФЫВАПРОЛДЖЭЁЯЧСМИТЬБЮ".downcase
-  # => "йцукенгшщзхъфывапролджэёячсмитьбю"
+# => "йцукенгшщзхъфывапролджэёячсмитьбю"
 "baﬄe".upcase # => "BAFFLE"
 ```
 
@@ -161,7 +161,7 @@ And even turkic is supported, where uppercase "i" is "İ" (an "I" with a dot):
 
 ```crystal
 "aeıiou".upcase(Unicode::CaseOptions::Turkic)
-  # => "AEIİOU"
+# => "AEIİOU"
 ```
 
 ## Random enhancements

--- a/_releases/2018-06-15-crystal-0.25.0-released.md
+++ b/_releases/2018-06-15-crystal-0.25.0-released.md
@@ -72,7 +72,7 @@ class Baz < Foo
 end
 
 var = rand < 0.5 ? Bar.new : Baz.new
-typeof(var) #=> Bar | Baz
+typeof(var) # => Bar | Baz
 ```
 
 Up to 0.24.2 the result was `typeof(var) #=> Foo`.

--- a/_releases/2019-04-17-crystal-0.28.0-released.md
+++ b/_releases/2019-04-17-crystal-0.28.0-released.md
@@ -64,8 +64,8 @@ The good stuff comes from its integration in std-lib. Check [#7179](https://gith
 ```crystal
 numbers = [1, 10, 3, 4, 5, 8]
 numbers.select(6..) # => [10, 8]
-numbers[..2] # => [1, 10, 3]
-numbers[...2] # => [1, 10]
+numbers[..2]        # => [1, 10, 3]
+numbers[...2]       # => [1, 10]
 
 [1, 2, 3].zip(6..) # => [[1, 6], [2, 7], [3, 8]]
 

--- a/_releases/2019-08-01-crystal-0.30.0-released.md
+++ b/_releases/2019-08-01-crystal-0.30.0-released.md
@@ -38,6 +38,7 @@ You don’t need to copy and paste it. A subtype can be used.
 
 ```crystal
 class Parent; end
+
 class Child < Parent; end
 
 abstract class Foo

--- a/_releases/2019-12-11-crystal-0.32.0-released.md
+++ b/_releases/2019-12-11-crystal-0.32.0-released.md
@@ -126,13 +126,13 @@ describe Foo do
   it "(2) a fast test", tags: "fast" do
   end
 
-  it "(3) a slow test", tags: "slow"do
+  it "(3) a slow test", tags: "slow" do
   end
 
   it "(4) a test with a star", tags: "starred" do
   end
 
-  it "(5) a slow test with a star", tags: %w(slow starred) do  # same as tags: ["slow", "starred"]
+  it "(5) a slow test with a star", tags: %w(slow starred) do # same as tags: ["slow", "starred"]
   end
 end
 ```
@@ -237,7 +237,7 @@ We are going to use:
 ```crystal
 puts ["Foo", "Bar", "Baz"].select(/^B/) # => ["Bar", "Baz"]
 # or
-puts ["Foo", "Bar", "Baz"].select {|word| word.starts_with?("B")} # => ["Bar", "Baz"]
+puts ["Foo", "Bar", "Baz"].select { |word| word.starts_with?("B") } # => ["Bar", "Baz"]
 ```
 
 Read more at [#8452](https://github.com/crystal-lang/crystal/pull/8452).

--- a/_releases/2020-04-06-crystal-0.34.0-released.md
+++ b/_releases/2020-04-06-crystal-0.34.0-released.md
@@ -56,11 +56,11 @@ The only case that will still have an implicit `else nil` is when there is no ex
 x = 1
 y = 2
 case
-when x.even?  # if x.even?
+when x.even? # if x.even?
   # ...
-when y >= 10  # elsif y >= 0
+when y >= 10 # elsif y >= 0
   # ...
-end           # end
+end # end
 ```
 
 Read more at [#8424](https://github.com/crystal-lang/crystal/pull/8424).

--- a/_releases/2020-06-09-crystal-0.35.0-released.md
+++ b/_releases/2020-06-09-crystal-0.35.0-released.md
@@ -134,9 +134,9 @@ We renamed `Log::Severity::Warning` to `Warn` in [#9293](https://github.com/crys
 The setup of logging got simpler. There are a couple of `Log.setup*` methods. Each of them will always set up the binding fully between sources and backends.
 
 ```crystal
-Log.setup :debug # will show debug or above in the stdout for all source
+Log.setup :debug         # will show debug or above in the stdout for all source
 Log.setup "db.*", :trace # will show trace or above in the stdout for db.* sources and nothing else
-Log.setup_from_env # will grab the value of LOG_LEVEL env variable
+Log.setup_from_env       # will grab the value of LOG_LEVEL env variable
 ```
 
 You might notice that `Log.setup_from_env` is now using a single environment variable as input. More flexibility will come later, but the new named arguments should offer a better experience. Read more at [#9145](https://github.com/crystal-lang/crystal/pull/9145).
@@ -147,13 +147,13 @@ One wanted feature that this enables is the possibility to attach local metadata
 
 ```crystal
 Log.info { "Program started" }
-Log.info &.emit("Program started") # same as previous
+Log.info &.emit("Program started")             # same as previous
 Log.info &.emit("User logged in", user_id: 42) # local data
 Log.info &.emit("User logged in", expr_that_computes_hash_named_tuple_or_metadata)
 Log.warn exception: e, &.emit("Oh no!", user_id: 42) # with exception
-Log.warn exception: e, &.emit("Oh no!") # with exception, no local data
-Log.warn(exception: e) { "Oh no!" } # same as previous
-Log.info &.emit(action: "log_in", user_id: 42) # empty message
+Log.warn exception: e, &.emit("Oh no!")              # with exception, no local data
+Log.warn(exception: e) { "Oh no!" }                  # same as previous
+Log.info &.emit(action: "log_in", user_id: 42)       # empty message
 ```
 
 How to create custom log formatters was revisited in [#9211](https://github.com/crystal-lang/crystal/pull/9211). Creating a formatter from a block or proc is still an option, but check in some simplified ways to define a formatter from a string directly.

--- a/_releases/2021-01-26-crystal-0.36.0-released.md
+++ b/_releases/2021-01-26-crystal-0.36.0-released.md
@@ -46,7 +46,7 @@ end
 
 class Bar < Foo
   def m(x) # Error: because Foo#m can be called with no argument.
-                #           Declare it as def m(x = 1) to make the compiler happy.
+    #           Declare it as def m(x = 1) to make the compiler happy.
   end
 end
 ```

--- a/_releases/2021-07-16-1.1.0-released.md
+++ b/_releases/2021-07-16-1.1.0-released.md
@@ -30,7 +30,7 @@ t1 = {1, 'a'}
 t2 = {true, *t1} # => {true, 1, 'a'}
 typeof(t2)       # => Tuple(Bool, Int32, Char)
 
-def f1(x : {Bool, *{Int32, Char}}); end       # Works in type annotations too
+def f1(x : {Bool, *{Int32, Char}}); end # Works in type annotations too
 def f2(x : Tuple(Bool, *{Int32, Char})); end
 
 ae = 'a'..'e'

--- a/_releases/2021-10-14-1.2.0-released.md
+++ b/_releases/2021-10-14-1.2.0-released.md
@@ -39,6 +39,7 @@ It is now possible to assign a subclass of a generic class to an element of [the
 
 ```crystal
 class A; end
+
 class B(T) < A; end
 
 x = A
@@ -79,8 +80,8 @@ Mutable collections now include a [`Indexable::Mutable(T)` module](https://githu
 ```crystal
 ary = BitArray.new(10) # => BitArray[0000000000]
 ary[0] = true
-ary                    # => BitArray[1000000000]
-ary.rotate!(-1)        # => BitArray[0100000000]
+ary             # => BitArray[1000000000]
+ary.rotate!(-1) # => BitArray[0100000000]
 ```
 
 Additionally, `Indexable::Mutable(T)` was expanded to include stable and unstable sorting methods ([#11254](https://github.com/crystal-lang/crystal/pull/11254), [#11029](https://github.com/crystal-lang/crystal/pull/11029), [#10163](https://github.com/crystal-lang/crystal/pull/10163)). The default `sort` operation now calls a stable algorithm.

--- a/_releases/2022-01-06-1.3.0-released.md
+++ b/_releases/2022-01-06-1.3.0-released.md
@@ -122,8 +122,8 @@ Multiple assignments got improved in various ways. First, it's possible to use a
 # Splat in multi-assign with array
 first, *rest, last = [1, 2, 3, 4, 5]
 first # => 1
-rest # => [2, 3, 4]
-last # => 5
+rest  # => [2, 3, 4]
+last  # => 5
 ```
 
 ```crystal
@@ -139,7 +139,7 @@ To take the first and last element, it is possible to use the _underscore splat_
 # Ignoring the elements in the middle
 first, *_, last = {"This", 15, 4, "tuple", true}
 first # => "This"
-last # => true
+last  # => true
 ```
 
 Second, there's an optional preview feature to detect unbalanced multi-assignments ([#11145](https://github.com/crystal-lang/crystal/pull/11145)). It can be enabled with the compiler flag `-Dstrict_multi_assign`.
@@ -171,7 +171,7 @@ end
 foo 1_i32 # Works in 1.2.2 and 1.3.0
 
 bar = 1_i32
-foo bar  # Fails in 1.2.2, works in 1.3.0
+foo bar # Fails in 1.2.2, works in 1.3.0
 ```
 
 Unsigned integer types can be autocasted into larger signed ones. And autocasting also works for floating point types (`Float32` to `Float64`).

--- a/_releases/2022-04-06-1.4.0-released.md
+++ b/_releases/2022-04-06-1.4.0-released.md
@@ -52,7 +52,7 @@ Version 1.4.0 ships with, at the moment, minimal support for compiling into WebA
 5. Link it with
 
    ```sh
-   wasm-ld main.wasm -o main-final.wasm  -L "$PWD/wasm32-wasi-libs" -lc -lpcre -lclang_rt.builtins-wasm32
+   wasm-ld main.wasm -o main-final.wasm -L "$PWD/wasm32-wasi-libs" -lc -lpcre -lclang_rt.builtins-wasm32
    ```
 
 6. Run the WebAssembly module with `wasmer main-final.wasm` or `wasmtime main-final.wasm` and have fun.
@@ -75,7 +75,6 @@ Now it compiles fine, inferring correctly that `@timer_countdown` has type `Time
 
 ```crystal
 class DisplayHello
-
   def initialize(delay : Time::Span)
     @timer_countdown = delay + 10.seconds
   end

--- a/_releases/2022-07-06-1.5.0-released.md
+++ b/_releases/2022-07-06-1.5.0-released.md
@@ -88,7 +88,7 @@ From 1.5.0, in an assignment like `@x = x`, parameter `x` gets the type of `@x`,
 It is now possible to add an annotation to a parameter of a method or macro. As illustration, imagine a linter that warns if a parameter is not used.
 
 ```crystal
-def foo(x); end  # Warning: argument `x` is not used
+def foo(x); end # Warning: argument `x` is not used
 ```
 
 Then, we could signal the linter to not warn us in a particular case. Assume the following annotation provided by the linter:
@@ -100,7 +100,7 @@ annotation MaybeUnused; end
 Applying it to the parameter removes the warning (in this particular fictitious linter):
 
 ```crystal
-def foo(@[MaybeUnused] x); end  # OK
+def foo(@[MaybeUnused] x); end # OK
 ```
 
 Details in [#12039](https://github.com/crystal-lang/crystal/issues/12039).

--- a/_releases/2025-04-09-1.16.0-released.md
+++ b/_releases/2025-04-09-1.16.0-released.md
@@ -80,8 +80,8 @@ In effect, this moves a runtime error condition to a compile time error.
 ```cr
 # Crystal 1.16.0
 [1, 10000000000_u64].sum # Error: `Enumerable#sum` and `#product` do not support Union types.
-                         # Instead, use `Enumerable#sum(initial)` and `#product(initial)`,
-                         # respectively, with an initial value of the intended type of the call.
+# Instead, use `Enumerable#sum(initial)` and `#product(initial)`,
+# respectively, with an initial value of the intended type of the call.
 
 # Crystal < 1.16.0
 [1, 10000000000_u64].sum # OverflowError: Arithmetic overflow

--- a/_releases/2025-07-16-1.17.0-released.md
+++ b/_releases/2025-07-16-1.17.0-released.md
@@ -269,8 +269,8 @@ name.
 require "socket"
 
 addr = Socket::IPAddress.new("fe80::1111%1", 0) # => Socket::IPAddress([fe80::1111%1]:0)
-addr.zone_id              # => 1
-addr.link_local_interface # => "lo"
+addr.zone_id                                    # => 1
+addr.link_local_interface                       # => "lo"
 ```
 
 _Thanks, [@foxxx0]_

--- a/devenv.nix
+++ b/devenv.nix
@@ -20,6 +20,16 @@
 
   packages = (with pkgs; [
     htmltest
+    # TODO: We don't run mdsf automatically with git-hooks due to several issue:
+    # - mdsf itself has critical bugs (e.g. https://github.com/hougesen/mdsf/issues/1702)
+    # - mdsf has no mechanism to exclude or disable specific files or lines
+    # - some code blocks use Crystal syntax highlighting but are not valid syntax,
+    #   which fails the formatter (e.g. they are excerpts or use outdated syntax)
+    # - mdsf only reports failure of a formatter, but without details. That makes
+    #   it hard to find and fix the problems.
+    mdsf
+    rufo
+    shfmt
   ]);
 
   processes.serve.exec = "make serve";

--- a/mdsf.json
+++ b/mdsf.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/hougesen/mdsf/main/schemas/v0.11.1/mdsf.schema.json",
+  "languages": {
+    "c": "clang-format",
+    "console": [],
+    "crystal": "crystal:format",
+    "diff": [],
+    "http": [],
+    "ini": [],
+    "irb": [],
+    "llvm": [],
+    "log": [],
+    "javascript": "prettier",
+    "powershell": [],
+    "pry": [],
+    "ruby": [
+      [
+        "rufo"
+      ]
+    ],
+    "shell": [
+      [
+        "shfmt",
+        "beautysh"
+      ]
+    ],
+    "slim": [],
+    "text": [],
+    "ucl": [],
+    "yaml": "prettier"
+  },
+  "language_aliases": {
+    "cr": "crystal",
+    "sh": "shell",
+    "shell-session": "console",
+    "terminal": "console"
+  }
+}


### PR DESCRIPTION
[mdsf](https://github.com/hougesen/mdsf) is a multiplex formatter which applies formatting to code blocks in markdown source code.

Unfortunately, it's still a very rough tool and has a lot of issue that makes it impossible to automate.

- mdsf itself has critical bugs (e.g. https://github.com/hougesen/mdsf/issues/1702)
- mdsf has no mechanism to exclude or disable specific files or lines
- some code blocks use Crystal syntax highlighting but are not valid syntax,
  which fails the formatter (e.g. they are excerpts or use outdated syntax)
- mdsf only reports failure of a formatter, but without details. That makes
  it hard to find and fix the problems.

Thus, we can't run mdsf automatically with git-hooks yet.
This patch adds mdsf to the devenv environment and its configuration. All the changes are manually verified.
