### PR TITLE
Fix side section layout [fixup #964]

### DIFF
--- a/_sass/components/_side-section.scss
+++ b/_sass/components/_side-section.scss
@@ -40,7 +40,7 @@
     margin: 0;
   }
 
-  > :is(h1, h2, h3, h4) {
+  > :is(h1, h2, h3, h4, .header-wrapper) {
     flex-basis: 100%;
   }
 }


### PR DESCRIPTION
The side section layout a used on the _Teams_ page has been broken since #964 which introduced a wrapper (`.header-wrapper`) around the section headers, but the layout expected the headers (`h3`) directly.