### PR TITLE
Update `exclude` paths in Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -78,18 +78,21 @@ social:
 
 exclude:
 - "*.nix"
+- "*.toml"
+- "*.yml"
+- "*.json"
 - "devenv*"
 - ".devenv/"
-- docker-compose.yml
-- docker-compose.*.yml
 - Gemfile
 - Gemfile.lock
 - Makefile
 - Rakefile
 - README.md
-- /scripts/
-- vendor
-- netlify.toml
+- scripts/
+- vendor/
+
+include:
+- "funding.json"
 
 sass:
   style: compressed


### PR DESCRIPTION
Some config files were missing. I figure it's easier to exclude all files with config extensions and include the few we actually want.