### PR TITLE
Rumdl: Set `kramdown` flavor

### DIFF
--- a/rumdl.toml
+++ b/rumdl.toml
@@ -6,6 +6,9 @@
 # * TODO: The rule might be useful, but we need to investigate whether we want to use it or not.
 
 [global]
+
+flavor = "kramdown"
+
 disable = [
   # MD014 - Show command output in documentation
   # TODO: Not sure if this is generally useful.


### PR DESCRIPTION
This doesn't have any immediate consequences, but it fine-tunes some rules specifically for the Markdown flavor of the kramdown parser.