### PR TITLE
Convert frontmatter URLs to source-relative

### DIFF
--- a/_includes/site/page-header.html
+++ b/_includes/site/page-header.html
@@ -8,7 +8,7 @@
   {%- if page.link_actions %}
     <nav class="link-actions" aria-label="Table of Contents">
       {%- for action in page.link_actions %}
-        {{- action | markdownify | remove: "<p>" | remove: "</p>" }}
+        {{- action | markdownify | rellinks | remove: "<p>" | remove: "</p>" }}
       {%- endfor %}
     </nav>
   {%- endif %}

--- a/_includes/site/page-header.html
+++ b/_includes/site/page-header.html
@@ -2,7 +2,7 @@
   <h1>{{ include.page_title | default: page.page_title | default: page.title | liquify }}</h1>
 
   <div class="page-description">
-    {{- page.description | markdownify }}
+    {{- page.description | markdownify | rellinks }}
   </div>
 
   {%- if page.link_actions %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -35,7 +35,7 @@ layout: base
     {%- if page.link_actions %}
       <nav class="link-actions" aria-label="Table of Contents">
         {%- for action in page.link_actions %}
-          {{- action | markdownify | remove: "<p>" | remove: "</p>" }}
+          {{- action | markdownify | rellinks | remove: "<p>" | remove: "</p>" }}
         {%- endfor %}
       </nav>
     {%- endif %}

--- a/_layouts/wide.html
+++ b/_layouts/wide.html
@@ -12,7 +12,7 @@ layout: base
   {%- if page.link_actions %}
     <nav class="link-actions" aria-label="Table of Contents">
       {%- for action in page.link_actions %}
-        {{- action | markdownify | remove: "<p>" | remove: "</p>" }}
+        {{- action | markdownify | rellinks | remove: "<p>" | remove: "</p>" }}
       {%- endfor %}
     </nav>
   {%- endif %}

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -8,7 +8,7 @@ link_actions:
   <a href="/feed.xml" rel="alternate" title="Newsfeed for Crystal blog posts" aria-label="Blog newsfeed" type="application/atom+xml">
     RSS
   </a>
-- "[Tags](https://crystal-lang.org/blog/tags/)"
+- "[Tags](blog/tags.md)"
 ---
 
 {% include posts/featured_news.html %}

--- a/_pages/install.md
+++ b/_pages/install.md
@@ -5,7 +5,7 @@ layout: page-wide
 page_class: page--segmented
 section: install
 description: |
-  Packages for [Crystal releases](https://crystal-lang.org/releases/) are available from different sources.
+  Packages for [Crystal releases](releases.md) are available from different sources.
   There are official ones provided the Crystal project, system packages and
   community-maintained packages.
   This page gives an overview of available installation methods.
@@ -18,8 +18,8 @@ link_actions:
 - '[![](/assets/install/android.svg) #Android](#android)'
 - '[![](/assets/install/docker.svg) #Docker](#docker)'
 - '[![](/assets/install/construction.svg) #Tools](#developer-tools)'
-- '[Nightlies](https://crystal-lang.org/install/nightlies/)'
-- '[Source](https://crystal-lang.org/install/from_sources/)'
+- '[Nightlies](install/nightlies.md)'
+- '[Source](install/from_sources.md)'
 ---
 
 ## Linux

--- a/_pages/newsletter.md
+++ b/_pages/newsletter.md
@@ -4,8 +4,8 @@ section: newsletter
 description: |
   Our newsletter regularly shares highlights and insights on the Crystal language and community.
 link_actions:
-- '[Archive](https://crystal-lang.org/newsletter/archive/)'
-- '[RSS Feed](https://crystal-lang.org/newsletter/feed/)'
+- '[Archive](newsletter/archive.md)'
+- '[RSS Feed](newsletter/feed.md)'
 ---
 
 {%- include site/newsletter-form.html %}

--- a/_pages/releases.md
+++ b/_pages/releases.md
@@ -11,7 +11,7 @@ link_actions:
 - <a href="https://crystal-lang.org/releases/feed.xml" rel="alternate" title="Newsfeed for Crystal releases" aria-label="Releases newsfeed" type="application/atom+xml">
     RSS
   </a>
-- '[Installation instructions](https://crystal-lang.org/install/)'
+- '[Installation instructions](install.md)'
 - '[GitHub Releases](https://github.com/crystal-lang/crystal/releases)'
 ---
 

--- a/_pages/success-stories.md
+++ b/_pages/success-stories.md
@@ -5,7 +5,7 @@ layout: wide
 description: |
   Experiences of Crystal adopted in production projects.
 link_actions:
-- '[Used in production](https://crystal-lang.org/used_in_prod/)'
+- '[Used in production](used_in_prod.md)'
 - '<a href="https://manas.tech/projects/crystal/crystal-compass/" title="Code Review as a Service from the makers of the language">Crystal Compass</a>'
 ---
 

--- a/_pages/used_in_prod.md
+++ b/_pages/used_in_prod.md
@@ -72,6 +72,6 @@ sections:
 
 {% include components/posts-list.html posts=site.categories.success limit=3 %}
 
-<div class="link-actions">
-  <a href="https://crystal-lang.org/success-stories/">More success stories</a>
+<div class="link-actions" markdown="1">
+  [More success stories](success-stories.md)
 </div>


### PR DESCRIPTION
This is a follow-up to #1119 and a proper fix for the problem of not being able to use source-relative links in the frontmatter.

The `relative-links` plugin has gained a `rellinks` filter as a new feature in https://github.com/benbalter/jekyll-relative-links/pull/98
That allows us to use relative links in frontmatter values and expand them in the same way as links in the markdown content.
It doesn't work for all use cases, or might just be challenging to implement. But it covers most.